### PR TITLE
FleeComponent now chooses the closestCharacter as instigator

### DIFF
--- a/src/main/java/org/terasology/behaviors/actions/FleeFromCharacterAction.java
+++ b/src/main/java/org/terasology/behaviors/actions/FleeFromCharacterAction.java
@@ -28,7 +28,7 @@ public class FleeFromCharacterAction extends BaseAction {
     public void construct(Actor actor) {
         FleeComponent fleeComponent = new FleeComponent();
         FindNearbyPlayersComponent component = actor.getComponent(FindNearbyPlayersComponent.class);
-        fleeComponent.instigator = component.charactersWithinRange.get(0);
+        fleeComponent.instigator = component.closestCharacter;
         actor.save(fleeComponent);
 
     }


### PR DESCRIPTION
**Before**
`FleeComponent` currently takes the first character of the `charactersWithinRange` list from `FindNearbyPlayersComponent`. 

Instead, now the `FleeComponent` chooses the closest character from the list, and assigns that as the instigator.