### PR TITLE
Add the ensure_target_present node prefab and action code

### DIFF
--- a/assets/prefabs/behaviorNodes/ensureTargetPresent.prefab
+++ b/assets/prefabs/behaviorNodes/ensureTargetPresent.prefab
@@ -1,0 +1,12 @@
+{
+  "BehaviorNode" : {
+    "action"    : "ensure_target_present",
+    "name"      : "ensure_target_present",
+    "displayName" : "EnsureTargetPresent",
+    "category"  : "logic",
+    "shape"     : "rect",
+    "description": "Check if target is present which is ready to mate.\nSUCCESS / FAILURE: if target is successfully found or not.",
+    "color"     : [180, 180, 180, 255],
+    "textColor" : [0, 0, 0, 255]
+  }
+}

--- a/src/main/java/org/terasology/behaviors/actions/EnsureTargetPresentAction.java
+++ b/src/main/java/org/terasology/behaviors/actions/EnsureTargetPresentAction.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.behaviors.actions;
+
+import org.terasology.logic.behavior.BehaviorAction;
+import org.terasology.logic.behavior.core.Actor;
+import org.terasology.logic.behavior.core.BaseAction;
+import org.terasology.logic.behavior.core.BehaviorState;
+import org.terasology.minion.move.MinionMoveComponent;
+
+@BehaviorAction(name = "ensure_target_present")
+public class EnsureTargetPresentAction extends BaseAction {
+    @Override
+    public BehaviorState modify(Actor actor, BehaviorState behaviorState) {
+        MinionMoveComponent minionMoveComponent = actor.getComponent(MinionMoveComponent.class);
+
+        if (minionMoveComponent.target != null) {
+            return BehaviorState.SUCCESS;
+        }
+        return BehaviorState.FAILURE;
+    }
+}


### PR DESCRIPTION
Added new node to implement the functionality of a `checkTargetSet` node deleted from the Pathfinding module([PR](https://github.com/Terasology/Pathfinding/pull/36)) to solve the [NPE issue](https://github.com/MovingBlocks/Terasology/issues/3310) while accessing BehaviorTrees.

TODO: Delete this node from the WildAnimalsGenome module to avoid redundancy.