### PR TITLE
Fixed neighbor finding loop and added probabilistic movement

### DIFF
--- a/assets/behaviors/common/doRandomMove.behavior
+++ b/assets/behaviors/common/doRandomMove.behavior
@@ -1,6 +1,8 @@
 {
   sequence : [
-    set_target_nearby_block,
+  {
+    set_target_nearby_block : { moveProbability: 65 }
+  },
     move_to
   ]
 }

--- a/src/main/java/org/terasology/minion/move/MoveToAction.java
+++ b/src/main/java/org/terasology/minion/move/MoveToAction.java
@@ -81,15 +81,17 @@ public class MoveToAction extends BaseAction {
         Vector3f drive = new Vector3f();
 
         float yaw = (float) Math.atan2(targetDirection.x, targetDirection.z);
+        float requestedYaw = 180f + yaw * TeraMath.RAD_TO_DEG;
+
+
         if((targetDirection.x < distance) && (targetDirection.y < distance) && (targetDirection.z < distance)) {
             drive.set(0, 0, 0);
             reachedTarget = true;
+            requestedYaw = 0f;
         } else {
             targetDirection.normalize();
             drive.set(targetDirection);
         }
-
-        float requestedYaw = 180f + yaw * TeraMath.RAD_TO_DEG;
 
         CharacterMoveInputEvent wantedInput = new CharacterMoveInputEvent(0, 0, requestedYaw, drive, false, false, moveComponent.jumpMode, (long) (actor.getDelta() * 1000));
         actor.getEntity().send(wantedInput);

--- a/src/main/java/org/terasology/minion/move/MoveToAction.java
+++ b/src/main/java/org/terasology/minion/move/MoveToAction.java
@@ -80,16 +80,15 @@ public class MoveToAction extends BaseAction {
         targetDirection.sub(moveComponent.target, worldPos);
         Vector3f drive = new Vector3f();
 
-        // TODO review - is the yaw here being calculated properly?
         float yaw = (float) Math.atan2(targetDirection.x, targetDirection.z);
-
-        if (targetDirection.x * targetDirection.x + targetDirection.z * targetDirection.z <= distance * distance) {
+        if((targetDirection.x < distance) && (targetDirection.y < distance) && (targetDirection.z < distance)) {
             drive.set(0, 0, 0);
             reachedTarget = true;
         } else {
             targetDirection.normalize();
             drive.set(targetDirection);
         }
+
         float requestedYaw = 180f + yaw * TeraMath.RAD_TO_DEG;
 
         CharacterMoveInputEvent wantedInput = new CharacterMoveInputEvent(0, 0, requestedYaw, drive, false, false, moveComponent.jumpMode, (long) (actor.getDelta() * 1000));

--- a/src/main/java/org/terasology/minion/move/SetTargetToNearbyBlockNode.java
+++ b/src/main/java/org/terasology/minion/move/SetTargetToNearbyBlockNode.java
@@ -56,18 +56,18 @@ public class SetTargetToNearbyBlockNode extends BaseAction {
 
     private WalkableBlock findRandomNearbyBlock(WalkableBlock startBlock) {
         WalkableBlock currentBlock = startBlock;
-
-        WalkableBlock[] neighbors = currentBlock.neighbors;
-        List<WalkableBlock> existingNeighbors = Lists.newArrayList();
-        for (WalkableBlock neighbor : neighbors) {
-            if (neighbor != null) {
-                existingNeighbors.add(neighbor);
+        for (int i = 0; i < random.nextInt(10) + 1; i++) {
+            WalkableBlock[] neighbors = currentBlock.neighbors;
+            List<WalkableBlock> existingNeighbors = Lists.newArrayList();
+            for (WalkableBlock neighbor : neighbors) {
+                if (neighbor != null) {
+                    existingNeighbors.add(neighbor);
+                }
+            }
+            if (existingNeighbors.size() > 0) {
+                currentBlock = existingNeighbors.get(random.nextInt(existingNeighbors.size()));
             }
         }
-        if (existingNeighbors.size() > 0) {
-            currentBlock = existingNeighbors.get(random.nextInt(existingNeighbors.size()));
-        }
-
         logger.debug(String.format("Looking for a block: my block is %s, found destination %s", startBlock.getBlockPosition(), currentBlock.getBlockPosition()));
         return currentBlock;
     }

--- a/src/main/java/org/terasology/minion/move/SetTargetToNearbyBlockNode.java
+++ b/src/main/java/org/terasology/minion/move/SetTargetToNearbyBlockNode.java
@@ -32,39 +32,40 @@ import java.util.Random;
 
 @BehaviorAction(name = "set_target_nearby_block")
 public class SetTargetToNearbyBlockNode extends BaseAction {
-    private static final int RANDOM_BLOCK_ITERATIONS = 10;
     private static final Logger logger = LoggerFactory.getLogger(SetTargetToNearbyBlockNode.class);
     private transient Random random = new Random();
     @In
     private PathfinderSystem pathfinderSystem;
 
+    private int moveProbability = 100;
 
     @Override
     public BehaviorState modify(Actor actor, BehaviorState result) {
-        MinionMoveComponent moveComponent = actor.getComponent(MinionMoveComponent.class);
-        if (moveComponent.currentBlock != null) {
-            WalkableBlock target = findRandomNearbyBlock(moveComponent.currentBlock);
-            moveComponent.target = target.getBlockPosition().toVector3f();
-            actor.save(moveComponent);
-        } else {
-            return BehaviorState.FAILURE;
+        if (random.nextInt(100) > (99 - moveProbability)) {
+            MinionMoveComponent moveComponent = actor.getComponent(MinionMoveComponent.class);
+            if (moveComponent.currentBlock != null) {
+                WalkableBlock target = findRandomNearbyBlock(moveComponent.currentBlock);
+                moveComponent.target = target.getBlockPosition().toVector3f();
+                actor.save(moveComponent);
+            } else {
+                return BehaviorState.FAILURE;
+            }
         }
         return BehaviorState.SUCCESS;
     }
 
     private WalkableBlock findRandomNearbyBlock(WalkableBlock startBlock) {
         WalkableBlock currentBlock = startBlock;
-        for (int i = 0; i < RANDOM_BLOCK_ITERATIONS; i++) {
-            WalkableBlock[] neighbors = currentBlock.neighbors;
-            List<WalkableBlock> existingNeighbors = Lists.newArrayList();
-            for (WalkableBlock neighbor : neighbors) {
-                if (neighbor != null) {
-                    existingNeighbors.add(neighbor);
-                }
+
+        WalkableBlock[] neighbors = currentBlock.neighbors;
+        List<WalkableBlock> existingNeighbors = Lists.newArrayList();
+        for (WalkableBlock neighbor : neighbors) {
+            if (neighbor != null) {
+                existingNeighbors.add(neighbor);
             }
-            if (existingNeighbors.size() > 0) {
-                currentBlock = existingNeighbors.get(random.nextInt(existingNeighbors.size()));
-            }
+        }
+        if (existingNeighbors.size() > 0) {
+            currentBlock = existingNeighbors.get(random.nextInt(existingNeighbors.size()));
         }
 
         logger.debug(String.format("Looking for a block: my block is %s, found destination %s", startBlock.getBlockPosition(), currentBlock.getBlockPosition()));


### PR DESCRIPTION
### Contains
- Partial fix for #15 
- Implements optional probabilistic movement for the movement action associated with the stray behavior

### Objective
Mitigate the synchronized stray behavior observed in the associated issue. Implementing a probabilistic movement action creates a visually smoother behavior for entities possessing the `stray` behavior and grouped in the same region.

### Changes

- Removed fixed variable for neighbor iteration in  `SetTargetToNearbyBlockNode` and replaced it with a random number generator
- Added the optional parameter `moveProbability` for the action `set_target_nearby_block` in `doRandomMove.behavior`
- Changed how the `reachedTarget` flag is raised in `MoveTo` minion action
- Added a yaw reset when the minion reaches the target

### Usage

The examples below show the usage of the `set_target_nearby_block` in conjunction with `doRandomMove.behavior`:

- Using the default settings (movement probability = 100%):

```
{
  sequence : [
    set_target_nearby_block,  
    move_to
  ]
}
```

- Settings the movement probability to a specific value (integer):

```
{
  sequence : [
  {
    set_target_nearby_block : { moveProbability: 65 }
  },
    move_to
  ]
}
```