### PR TITLE
Listen for path calculation in FindPathToNode

### DIFF
--- a/src/main/java/org/terasology/minion/move/FindPathToNode.java
+++ b/src/main/java/org/terasology/minion/move/FindPathToNode.java
@@ -62,6 +62,8 @@ public class FindPathToNode extends BaseAction {
         if(pathfinderSystem==null){setup();}
         final MinionMoveComponent moveComponent = actor.getComponent(MinionMoveComponent.class);
         Vector3f targetLocation = moveComponent.target;
+        moveComponent.path = null;
+        actor.save(moveComponent);
         WalkableBlock currentBlock = moveComponent.currentBlock;
         if (currentBlock == null || targetLocation == null) {
             moveComponent.path = Path.INVALID;
@@ -91,7 +93,7 @@ public class FindPathToNode extends BaseAction {
                     public void onFailure(Throwable t) {
                         moveComponent.path = Path.INVALID;
                     }
-        }, MoreExecutors.directExecutor());
+        });
     }
 
     @Override

--- a/src/main/java/org/terasology/minion/move/FindPathToNode.java
+++ b/src/main/java/org/terasology/minion/move/FindPathToNode.java
@@ -17,6 +17,7 @@ package org.terasology.minion.move;
 
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
 import org.terasology.logic.behavior.BehaviorAction;
 import org.terasology.logic.behavior.core.Actor;
@@ -90,7 +91,7 @@ public class FindPathToNode extends BaseAction {
                     public void onFailure(Throwable t) {
                         moveComponent.path = Path.INVALID;
                     }
-        });
+        }, MoreExecutors.directExecutor());
     }
 
     @Override

--- a/src/main/java/org/terasology/minion/move/MoveAlongPathNode.java
+++ b/src/main/java/org/terasology/minion/move/MoveAlongPathNode.java
@@ -41,7 +41,7 @@ import org.terasology.registry.In;
 public class MoveAlongPathNode extends BaseAction {
     private static final Logger logger = LoggerFactory.getLogger(MoveAlongPathNode.class);
 
-    @In
+    // @In
     private transient PathRenderSystem pathRenderSystem;
 
     @Override

--- a/src/main/java/org/terasology/minion/move/MoveAlongPathNode.java
+++ b/src/main/java/org/terasology/minion/move/MoveAlongPathNode.java
@@ -26,6 +26,7 @@ import org.terasology.math.geom.Vector3f;
 import org.terasology.navgraph.WalkableBlock;
 import org.terasology.pathfinding.componentSystem.PathRenderSystem;
 import org.terasology.pathfinding.model.Path;
+import org.terasology.registry.CoreRegistry;
 import org.terasology.registry.In;
 
 /**
@@ -45,6 +46,9 @@ public class MoveAlongPathNode extends BaseAction {
 
     @Override
     public void construct(Actor actor) {
+        // TODO: Temporary fix for injection malfunction in actions, ideally remove this in the future.
+        pathRenderSystem = CoreRegistry.get(PathRenderSystem.class);
+
         MinionMoveComponent moveComponent = actor.getComponent(MinionMoveComponent.class);
         if (moveComponent != null && moveComponent.path != null && moveComponent.path != Path.INVALID) {
             pathRenderSystem.addPath(moveComponent.path);


### PR DESCRIPTION
## Contains
Inside `FindPathToNode`, a path is requested from the pathfinding system, but the result is not saved to the character's `MinionMoveComponent`. This pull request adds a callback to save the generated path to the move component once the calculation is finished.

**Requires Terasology/Pathfinding#39 to work!**

## Todo

- [x] Fix path saving error
- [x] Add test character in Terasology/TutorialBehaviors