### PR TITLE
Transfer continuous pathfinding nodes from TutorialBehaviors#5

### DIFF
--- a/assets/behaviors/pathfinding/dynamicPathfindingFollow.behavior
+++ b/assets/behaviors/pathfinding/dynamicPathfindingFollow.behavior
@@ -1,0 +1,38 @@
+{
+    sequence: [
+        {
+            animation : {
+                play: "engine:Walk.animationPool",
+                loop: "engine:Walk.animationPool"
+            }
+        },
+        {
+            set_speed : {
+                speedMultiplier: 0.4
+            }
+        },
+        {
+            loop: {
+                child: {
+                    sequence: [
+                        set_target_to_followed_entity,
+                        find_path,
+                        setup_continuous_pathfinding,
+                        {
+                            timeout: {
+                                time: 3,
+                                child: {
+                                    move_along_path_continuous: {
+                                        child: {
+                                            move_to: {}
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+}

--- a/assets/behaviors/pathfinding/pointPathfindingFollow.behavior
+++ b/assets/behaviors/pathfinding/pointPathfindingFollow.behavior
@@ -15,7 +15,6 @@
             loop: {
                 child: {
                     sequence: [
-                        set_target_to_followed_entity,
                         find_path,
                         {
                             move_along_path: {

--- a/assets/behaviors/pathfinding/pointPathfindingFollow.behavior
+++ b/assets/behaviors/pathfinding/pointPathfindingFollow.behavior
@@ -1,0 +1,32 @@
+{
+    sequence: [
+        {
+            animation : {
+                play: "engine:Walk.animationPool",
+                loop: "engine:Walk.animationPool"
+            }
+        },
+        {
+            set_speed : {
+                speedMultiplier: 0.4
+            }
+        },
+        {
+            loop: {
+                child: {
+                    sequence: [
+                        set_target_to_followed_entity,
+                        find_path,
+                        {
+                            move_along_path: {
+                                child: {
+                                    move_to: {}
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+}

--- a/assets/behaviors/pathfinding/staticPathfindingFollow.behavior
+++ b/assets/behaviors/pathfinding/staticPathfindingFollow.behavior
@@ -1,0 +1,32 @@
+{
+    sequence: [
+        {
+            animation : {
+                play: "engine:Walk.animationPool",
+                loop: "engine:Walk.animationPool"
+            }
+        },
+        {
+            set_speed : {
+                speedMultiplier: 0.4
+            }
+        },
+        {
+            loop: {
+                child: {
+                    sequence: [
+                        set_target_to_followed_entity,
+                        find_path,
+                        {
+                            move_along_path: {
+                                child: {
+                                    move_to: {}
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+}

--- a/module.txt
+++ b/module.txt
@@ -1,6 +1,6 @@
 {
     "id" : "Behaviors",
-    "version" : "0.2.0-SNAPSHOT",
+    "version" : "0.2.1-SNAPSHOT",
     "author" : "synopia, dkambersky",
     "displayName" : "Behaviors",
     "description" : "A set of behavior traits which could be applied to creatures and NPCs",

--- a/src/main/java/org/terasology/minion/move/ContinuousMoveAlongPathNode.java
+++ b/src/main/java/org/terasology/minion/move/ContinuousMoveAlongPathNode.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2018 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.minion.move;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terasology.logic.behavior.BehaviorAction;
+import org.terasology.logic.behavior.core.Actor;
+import org.terasology.logic.behavior.core.BaseAction;
+import org.terasology.logic.behavior.core.BehaviorState;
+import org.terasology.logic.location.LocationComponent;
+import org.terasology.math.geom.Vector3f;
+import org.terasology.navgraph.WalkableBlock;
+import org.terasology.pathfinding.componentSystem.PathRenderSystem;
+import org.terasology.pathfinding.model.Path;
+import org.terasology.registry.CoreRegistry;
+
+/**
+ * Call child node, as long as the actor has not reached the end of the path. Sets <b>MinionMoveComponent.target</b> to next step in path.<br/> Old construct() from
+ * original {@link MoveAlongPathNode} moved to {@link SetupContinuousMoveNode} to allow for path travelling to be interrupted. This enables a character to follow
+ * a moving target.
+ * <br/>
+ * <b>SUCCESS</b>: when actor has reached end of path.<br/>
+ * <b>FAILURE</b>: if no path was found previously.<br/>
+ * <br/>
+ */
+@BehaviorAction(name = "move_along_path_continuous", isDecorator = true)
+public class ContinuousMoveAlongPathNode extends BaseAction {
+
+    @Override
+    public BehaviorState modify(Actor actor, BehaviorState result) {
+        MinionMoveComponent moveComponent = actor.getComponent(MinionMoveComponent.class);
+        if (result != BehaviorState.SUCCESS) {
+            return result;
+        }
+        moveComponent.currentIndex++;
+        if (moveComponent.currentIndex < moveComponent.path.size()) {
+            WalkableBlock block = moveComponent.path.get(moveComponent.currentIndex);
+            Vector3f pos = block.getBlockPosition().toVector3f();
+            pos.add(new Vector3f(0, 1, 0));
+            moveComponent.target = pos;
+            actor.save(moveComponent);
+            return BehaviorState.RUNNING;
+        } else {
+            moveComponent.path = null;
+            actor.save(moveComponent);
+            return BehaviorState.SUCCESS;
+        }
+    }
+
+}

--- a/src/main/java/org/terasology/minion/move/ContinuousMoveAlongPathNode.java
+++ b/src/main/java/org/terasology/minion/move/ContinuousMoveAlongPathNode.java
@@ -29,8 +29,9 @@ import org.terasology.pathfinding.model.Path;
 import org.terasology.registry.CoreRegistry;
 
 /**
- * Call child node, as long as the actor has not reached the end of the path. Sets <b>MinionMoveComponent.target</b> to next step in path.<br/> Old construct() from
- * original {@link MoveAlongPathNode} moved to {@link SetupContinuousMoveNode} to allow for path travelling to be interrupted. This enables a character to follow
+ * Call child node, as long as the actor has not reached the end of the path. Sets <b>MinionMoveComponent.target</b> to
+ * next step in path.<br/> Old construct() from original {@link MoveAlongPathNode} moved to
+ * {@link SetupContinuousMoveNode} to allow for path travelling to be interrupted. This enables a character to follow
  * a moving target.
  * <br/>
  * <b>SUCCESS</b>: when actor has reached end of path.<br/>

--- a/src/main/java/org/terasology/minion/move/SetupContinuousMoveNode.java
+++ b/src/main/java/org/terasology/minion/move/SetupContinuousMoveNode.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2018 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.minion.move;
+
+import org.terasology.logic.behavior.BehaviorAction;
+import org.terasology.logic.behavior.core.Actor;
+import org.terasology.logic.behavior.core.BaseAction;
+import org.terasology.logic.behavior.core.BehaviorState;
+import org.terasology.navgraph.WalkableBlock;
+import org.terasology.pathfinding.model.Path;
+
+/**
+ * Essential setup for a character to travel along a determined path. This is exported from {@link MoveAlongPathNode#construct(Actor)}, which allows for characters to
+ * interrupt travelling along a path. This is essential for characters following a moving object.
+ */
+@BehaviorAction(name = "setup_continuous_pathfinding")
+public class SetupContinuousMoveNode extends BaseAction {
+
+    @Override
+    public BehaviorState modify(Actor actor, BehaviorState result) {
+
+        MinionMoveComponent moveComponent = actor.getComponent(MinionMoveComponent.class);
+        if (moveComponent != null && moveComponent.path != null && moveComponent.path != Path.INVALID) {
+            moveComponent.currentIndex = 0;
+            WalkableBlock block = moveComponent.path.get(moveComponent.currentIndex);
+            moveComponent.target = block.getBlockPosition().toVector3f();
+            actor.save(moveComponent);
+
+            return BehaviorState.SUCCESS;
+        }
+
+        return BehaviorState.FAILURE;
+    }
+
+}

--- a/src/main/java/org/terasology/minion/move/SetupContinuousMoveNode.java
+++ b/src/main/java/org/terasology/minion/move/SetupContinuousMoveNode.java
@@ -23,8 +23,9 @@ import org.terasology.navgraph.WalkableBlock;
 import org.terasology.pathfinding.model.Path;
 
 /**
- * Essential setup for a character to travel along a determined path. This is exported from {@link MoveAlongPathNode#construct(Actor)}, which allows for characters to
- * interrupt travelling along a path. This is essential for characters following a moving object.
+ * Essential setup for a character to travel along a determined path. This is exported from
+ * {@link MoveAlongPathNode#construct(Actor)}, which allows for characters to interrupt travelling along a path.
+ * This is essential for characters following a moving object.
  */
 @BehaviorAction(name = "setup_continuous_pathfinding")
 public class SetupContinuousMoveNode extends BaseAction {


### PR DESCRIPTION
## Contains

Pathfinding nodes used in Terasology/TutorialBehaviors#5 to allow continuous pathfinding, so all gameplay modules can use these nodes. The `pathfindingFollow` behavior tree has been split into `pointPathfindingFollow`, `staticPathfindingFollow` and `dynamicPathfindingFollow`. The first is for following a determined target, the second for following a static entity, and the third for following a moving entity.