### PR TITLE
Fixed: general orientation bug

### DIFF
--- a/assets/behaviors/creatures/critter.behavior
+++ b/assets/behaviors/creatures/critter.behavior
@@ -2,7 +2,7 @@
   dynamic: [
       {
         guard: {
-          componentPresent: "Behaviors:Flee",
+          componentPresent: "Behaviors:Fleeing",
           child: {
             sequence: [
             check_flee_stop,

--- a/src/main/java/org/terasology/behaviors/actions/CheckFleeStopAction.java
+++ b/src/main/java/org/terasology/behaviors/actions/CheckFleeStopAction.java
@@ -17,7 +17,7 @@ package org.terasology.behaviors.actions;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.terasology.behaviors.components.FleeComponent;
+import org.terasology.behaviors.components.FleeingComponent;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.logic.behavior.BehaviorAction;
 import org.terasology.logic.behavior.core.Actor;
@@ -35,8 +35,8 @@ public class CheckFleeStopAction extends BaseAction {
     @Override
     public BehaviorState modify(Actor actor, BehaviorState result) {
 
-        FleeComponent fleeComponent = actor.getComponent(FleeComponent.class);
-        EntityRef instigator = fleeComponent.instigator;
+        FleeingComponent fleeingComponent = actor.getComponent(FleeingComponent.class);
+        EntityRef instigator = fleeingComponent.instigator;
         if (instigator == null || !instigator.isActive()) {
             return BehaviorState.FAILURE;
         }
@@ -52,11 +52,11 @@ public class CheckFleeStopAction extends BaseAction {
         Vector3f selfLocation = targetLocation.getWorldPosition();
         float currentDistanceSquared = selfLocation.distanceSquared(instigatorLocation);
 
-        float minDistance = fleeComponent.minDistance;
+        float minDistance = fleeingComponent.minDistance;
         float minDistanceSquared = minDistance * minDistance;
 
         if (currentDistanceSquared >= minDistanceSquared) {
-            actor.getEntity().removeComponent(FleeComponent.class);
+            actor.getEntity().removeComponent(FleeingComponent.class);
             return BehaviorState.FAILURE;
         } else {
             return BehaviorState.SUCCESS;

--- a/src/main/java/org/terasology/behaviors/actions/FleeFromCharacterAction.java
+++ b/src/main/java/org/terasology/behaviors/actions/FleeFromCharacterAction.java
@@ -16,7 +16,7 @@
 package org.terasology.behaviors.actions;
 
 import org.terasology.behaviors.components.FindNearbyPlayersComponent;
-import org.terasology.behaviors.components.FleeComponent;
+import org.terasology.behaviors.components.FleeingComponent;
 import org.terasology.logic.behavior.BehaviorAction;
 import org.terasology.logic.behavior.core.Actor;
 import org.terasology.logic.behavior.core.BaseAction;
@@ -26,10 +26,10 @@ import org.terasology.logic.behavior.core.BehaviorState;
 public class FleeFromCharacterAction extends BaseAction {
     @Override
     public void construct(Actor actor) {
-        FleeComponent fleeComponent = new FleeComponent();
+        FleeingComponent fleeingComponent = new FleeingComponent();
         FindNearbyPlayersComponent component = actor.getComponent(FindNearbyPlayersComponent.class);
-        fleeComponent.instigator = component.closestCharacter;
-        actor.save(fleeComponent);
+        fleeingComponent.instigator = component.closestCharacter;
+        actor.save(fleeingComponent);
 
     }
 

--- a/src/main/java/org/terasology/behaviors/actions/SetTargetToNearbyBlockAwayFromInstigatorAction.java
+++ b/src/main/java/org/terasology/behaviors/actions/SetTargetToNearbyBlockAwayFromInstigatorAction.java
@@ -18,7 +18,7 @@ package org.terasology.behaviors.actions;
 import com.google.common.collect.Lists;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.terasology.behaviors.components.FleeComponent;
+import org.terasology.behaviors.components.FleeingComponent;
 import org.terasology.logic.behavior.BehaviorAction;
 import org.terasology.logic.behavior.core.Actor;
 import org.terasology.logic.behavior.core.BaseAction;
@@ -63,8 +63,8 @@ public class SetTargetToNearbyBlockAwayFromInstigatorAction extends BaseAction {
 
     private WalkableBlock findRandomNearbyBlockAwayFromPlayer(WalkableBlock startBlock, Actor actor) {
         WalkableBlock currentBlock = startBlock;
-        FleeComponent fleeComponent = actor.getComponent(FleeComponent.class);
-        Vector3i playerPosition = new Vector3i(fleeComponent.instigator.getComponent(LocationComponent.class).getWorldPosition());
+        FleeingComponent fleeingComponent = actor.getComponent(FleeingComponent.class);
+        Vector3i playerPosition = new Vector3i(fleeingComponent.instigator.getComponent(LocationComponent.class).getWorldPosition());
         for (int i = 0; i < RANDOM_BLOCK_ITERATIONS; i++) {
             WalkableBlock[] neighbors = currentBlock.neighbors;
             List<WalkableBlock> existingNeighbors = Lists.newArrayList();

--- a/src/main/java/org/terasology/behaviors/components/FleeingComponent.java
+++ b/src/main/java/org/terasology/behaviors/components/FleeingComponent.java
@@ -22,7 +22,7 @@ import org.terasology.entitySystem.entity.EntityRef;
  * This components is used by the FleeOnHit and FleeInProximity module to allow an
  * NPC to exhibit the Flee behavior
  */
-public class FleeComponent implements Component {
+public class FleeingComponent implements Component {
     /* Minimum distance from instigator after which the NPC will stop 'flee'ing */
     public float minDistance = 10f;
     /* Entity to run away from */

--- a/src/main/java/org/terasology/behaviors/system/BehaviorsEventSystem.java
+++ b/src/main/java/org/terasology/behaviors/system/BehaviorsEventSystem.java
@@ -26,7 +26,7 @@ import org.terasology.logic.health.event.OnDamagedEvent;
 import org.terasology.behaviors.components.FollowComponent;
 import org.terasology.registry.In;
 import org.terasology.behaviors.components.AttackOnHitComponent;
-import org.terasology.behaviors.components.FleeComponent;
+import org.terasology.behaviors.components.FleeingComponent;
 import org.terasology.behaviors.components.FleeOnHitComponent;
 
 
@@ -43,10 +43,10 @@ public class BehaviorsEventSystem extends BaseComponentSystem {
     public void onDamage(OnDamagedEvent event, EntityRef entity) {
 
         // Make entity flee
-        FleeComponent fleeComponent = new FleeComponent();
-        fleeComponent.instigator = event.getInstigator();
-        fleeComponent.minDistance = entity.getComponent(FleeOnHitComponent.class).minDistance;
-        entity.saveComponent(fleeComponent);
+        FleeingComponent fleeingComponent = new FleeingComponent();
+        fleeingComponent.instigator = event.getInstigator();
+        fleeingComponent.minDistance = entity.getComponent(FleeOnHitComponent.class).minDistance;
+        entity.saveComponent(fleeingComponent);
 
         // Increase speed by multiplier factor
         CharacterMovementComponent characterMovementComponent = entity.getComponent(CharacterMovementComponent.class);

--- a/src/main/java/org/terasology/minion/move/MinionMoveComponent.java
+++ b/src/main/java/org/terasology/minion/move/MinionMoveComponent.java
@@ -37,7 +37,7 @@ public class MinionMoveComponent implements Component {
     public boolean targetReached;
     public boolean breaking;
 
-    public Path path;
+    public transient Path path;
     public int currentIndex;
 
     public transient WalkableBlock currentBlock;

--- a/src/main/java/org/terasology/minion/move/MoveToAction.java
+++ b/src/main/java/org/terasology/minion/move/MoveToAction.java
@@ -79,15 +79,12 @@ public class MoveToAction extends BaseAction {
         Vector3f targetDirection = new Vector3f();
         targetDirection.sub(moveComponent.target, worldPos);
         Vector3f drive = new Vector3f();
-
         float yaw = (float) Math.atan2(targetDirection.x, targetDirection.z);
         float requestedYaw = 180f + yaw * TeraMath.RAD_TO_DEG;
-
 
         if((targetDirection.x < distance) && (targetDirection.y < distance) && (targetDirection.z < distance)) {
             drive.set(0, 0, 0);
             reachedTarget = true;
-            requestedYaw = 0f;
         } else {
             targetDirection.normalize();
             drive.set(targetDirection);

--- a/src/main/java/org/terasology/minion/move/SetTargetToNearbyBlockNode.java
+++ b/src/main/java/org/terasology/minion/move/SetTargetToNearbyBlockNode.java
@@ -56,7 +56,7 @@ public class SetTargetToNearbyBlockNode extends BaseAction {
 
     private WalkableBlock findRandomNearbyBlock(WalkableBlock startBlock) {
         WalkableBlock currentBlock = startBlock;
-        for (int i = 0; i < random.nextInt(10) + 1; i++) {
+        for (int i = 0; i < random.nextInt(10) + 3; i++) {
             WalkableBlock[] neighbors = currentBlock.neighbors;
             List<WalkableBlock> existingNeighbors = Lists.newArrayList();
             for (WalkableBlock neighbor : neighbors) {


### PR DESCRIPTION
### Contains
- Fix for the "general orientation" bug inserted by PR #16 and described in the comments section of PR #21 
- Fix related to the visual flipping behavior of creatures 
- Refactoring: renamed `FleeComponent` to `FleeingComponent`

### Objective
This is a continuation of PR #16 on the subject of mitigating the synchronized stray behavior. This PR fixes the "general orientation"bug inserted by PR #16 and mitigates the visual flipping effect of creatures. The latter is caused by a orientation change derived from the movement to a neighbor block, which causes the impression that the creature just flipped its original orientation to a new one. This effect is mitigated by forcing a higher minimal number of neighbor interactions when setting the target destination for the creature, which causes it to statistically choose a farther destination, and therefore making a perceptible movement when changing its original orientation. The mitigation is statistical since the number of interactions over an initial list of neighbor blocks is based on a random function, and there's a change that after a number of interactions the target destination is still set to a neighbor block.

### Changes

- Removed yaw reset on `MoveTo` action
- Increased the number of neighbor interactions on `SetTargetToNearbyBlockNode.findRandomNearbyBlock()`
- Refactoring: renamed `FleeComponent` to `FleeingComponent` and all related references