### PR TITLE
Make MinionMoveComponent.path a transient field

### DIFF
--- a/src/main/java/org/terasology/minion/move/MinionMoveComponent.java
+++ b/src/main/java/org/terasology/minion/move/MinionMoveComponent.java
@@ -37,7 +37,7 @@ public class MinionMoveComponent implements Component {
     public boolean targetReached;
     public boolean breaking;
 
-    public Path path;
+    public transient Path path;
     public int currentIndex;
 
     public transient WalkableBlock currentBlock;


### PR DESCRIPTION
This helps avoid running into a StackOverflowError during save serialization.