### PR TITLE
fix: Replace `saveComponent` calls with `addOrSaveComponent`

### DIFF
--- a/src/main/java/org/terasology/behaviors/system/BehaviorsEventSystem.java
+++ b/src/main/java/org/terasology/behaviors/system/BehaviorsEventSystem.java
@@ -46,12 +46,12 @@ public class BehaviorsEventSystem extends BaseComponentSystem {
         FleeingComponent fleeingComponent = new FleeingComponent();
         fleeingComponent.instigator = event.getInstigator();
         fleeingComponent.minDistance = entity.getComponent(FleeOnHitComponent.class).minDistance;
-        entity.saveComponent(fleeingComponent);
+        entity.addOrSaveComponent(fleeingComponent);
 
         // Increase speed by multiplier factor
         CharacterMovementComponent characterMovementComponent = entity.getComponent(CharacterMovementComponent.class);
         characterMovementComponent.speedMultiplier = entity.getComponent(FleeOnHitComponent.class).speedMultiplier;
-        entity.saveComponent(characterMovementComponent);
+        entity.addOrSaveComponent(characterMovementComponent);
 
     }
 


### PR DESCRIPTION
When the entity first receives damage (`onDamage()`) the `FleeingComponent` is not present by default - using the method `addOrSaveComponent` here is more adequate, and it'll get rid of a meaningless error message in the console:

`[main] ERROR o.t.e.e.internal.PojoEntityManager - Saving a component (class org.terasology.behaviors.components.FleeingComponent) that doesn't belong to this entity`