### PR TITLE
feat: Add territorial critter behavior [GCI 2019]

### DIFF
--- a/assets/behaviors/creatures/territorialCritter.behavior
+++ b/assets/behaviors/creatures/territorialCritter.behavior
@@ -1,0 +1,41 @@
+{
+  "selector": [
+    {
+      "guard": {
+        "componentPresent": "Behaviors:TerritoryDistance",
+        "values": ["V distanceSquared < 25"],
+        "child": {
+          "selector": [
+            {
+              "guard": {
+                "componentPresent": "Behaviors:FindNearbyPlayers",
+                "values": ["N charactersWithinRange nonEmpty"],
+                "child": {
+                    "sequence": [
+                      "set_target_nearby_player",
+                      {
+                        "lookup": {
+                          "tree": "Behaviors:hostile"
+                        }
+                      }
+                   ]
+                }
+              }
+            },
+            {
+              "lookup": {
+                "tree": "Behaviors:stray"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "sequence": [
+        "set_target_territory",
+        "move_to"
+      ]
+    }
+  ]
+}

--- a/src/main/java/org/terasology/behaviors/actions/SetTargetToNearbyPlayer.java
+++ b/src/main/java/org/terasology/behaviors/actions/SetTargetToNearbyPlayer.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.behaviors.actions;
+
+import org.terasology.behaviors.components.AttackOnHitComponent;
+import org.terasology.behaviors.components.FindNearbyPlayersComponent;
+import org.terasology.behaviors.components.FollowComponent;
+import org.terasology.engine.Time;
+import org.terasology.logic.behavior.BehaviorAction;
+import org.terasology.logic.behavior.core.Actor;
+import org.terasology.logic.behavior.core.BaseAction;
+import org.terasology.logic.behavior.core.BehaviorState;
+import org.terasology.registry.In;
+
+@BehaviorAction(name = "set_target_nearby_player")
+public class SetTargetToNearbyPlayer extends BaseAction {
+    @In
+    private Time time;
+
+    @Override
+    public BehaviorState modify(Actor actor, BehaviorState result) {
+        if (!actor.hasComponent(AttackOnHitComponent.class) || !actor.hasComponent(FindNearbyPlayersComponent.class)) {
+            return BehaviorState.FAILURE;
+        }
+
+        AttackOnHitComponent attackOnHitComponent = actor.getComponent(AttackOnHitComponent.class);
+        attackOnHitComponent.instigator = actor.getComponent(FindNearbyPlayersComponent.class).closestCharacter;
+        attackOnHitComponent.timeWhenHit = time.getGameTimeInMs();
+        actor.save(attackOnHitComponent);
+
+        FollowComponent followComponent = new FollowComponent();
+        followComponent.entityToFollow = attackOnHitComponent.instigator;
+        actor.getEntity().addOrSaveComponent(followComponent);
+
+        return BehaviorState.SUCCESS;
+    }
+}

--- a/src/main/java/org/terasology/behaviors/actions/SetTargetToTerritory.java
+++ b/src/main/java/org/terasology/behaviors/actions/SetTargetToTerritory.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.behaviors.actions;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terasology.behaviors.components.TerritoryDistance;
+import org.terasology.logic.behavior.BehaviorAction;
+import org.terasology.logic.behavior.core.Actor;
+import org.terasology.logic.behavior.core.BaseAction;
+import org.terasology.logic.behavior.core.BehaviorState;
+import org.terasology.math.geom.Vector3f;
+import org.terasology.minion.move.MinionMoveComponent;
+
+@BehaviorAction(name = "set_target_territory")
+public class SetTargetToTerritory extends BaseAction {
+    @Override
+    public BehaviorState modify(Actor actor, BehaviorState result) {
+        if (!actor.hasComponent(TerritoryDistance.class) || !actor.hasComponent(MinionMoveComponent.class)) {
+            return BehaviorState.FAILURE;
+        }
+
+        Vector3f territory = actor.getComponent(TerritoryDistance.class).location;
+
+        MinionMoveComponent moveComponent = actor.getComponent(MinionMoveComponent.class);
+        if (moveComponent.target.equals(territory)) {
+            return BehaviorState.SUCCESS;
+        }
+
+        moveComponent.target = territory;
+        actor.save(moveComponent);
+
+        return BehaviorState.SUCCESS;
+    }
+}

--- a/src/main/java/org/terasology/behaviors/components/TerritoryDistance.java
+++ b/src/main/java/org/terasology/behaviors/components/TerritoryDistance.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2020 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.behaviors.components;
+
+import org.terasology.entitySystem.Component;
+import org.terasology.math.geom.Vector3f;
+
+public class TerritoryDistance implements Component {
+    public float distanceSquared;
+    public Vector3f location;
+}

--- a/src/main/java/org/terasology/behaviors/system/TerritorialBehaviourSystem.java
+++ b/src/main/java/org/terasology/behaviors/system/TerritorialBehaviourSystem.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2020 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.behaviors.system;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terasology.behaviors.components.TerritoryDistance;
+import org.terasology.entitySystem.entity.EntityManager;
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.entity.lifecycleEvents.OnActivatedComponent;
+import org.terasology.entitySystem.event.ReceiveEvent;
+import org.terasology.entitySystem.systems.BaseComponentSystem;
+import org.terasology.entitySystem.systems.RegisterMode;
+import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.entitySystem.systems.UpdateSubscriberSystem;
+import org.terasology.logic.location.LocationComponent;
+import org.terasology.math.geom.Vector3f;
+import org.terasology.registry.In;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+@RegisterSystem(RegisterMode.AUTHORITY)
+public class TerritorialBehaviourSystem extends BaseComponentSystem implements UpdateSubscriberSystem {
+    @In
+    public EntityManager entityManager;
+    private List<Vector3f> territories = new ArrayList<Vector3f>();
+    private Random random = new Random();
+    private static Logger logger = LoggerFactory.getLogger(TerritorialBehaviourSystem.class);
+
+    @Override
+    public void initialise() {
+        territories.clear();
+    }
+
+    /**
+     * Update function for the Component System, which is called each
+     * time the engine is updated.
+     *
+     * @param delta The time (in seconds) since the last engine update.
+     */
+    @Override
+    public void update(float delta) {
+        for (EntityRef entity : entityManager.getEntitiesWith(TerritoryDistance.class, LocationComponent.class)) {
+            TerritoryDistance territoryDistance = entity.getComponent(TerritoryDistance.class);
+            territoryDistance.distanceSquared = territoryDistance.location.distanceSquared(entity.getComponent(LocationComponent.class).getWorldPosition());
+            entity.saveComponent(territoryDistance);
+        }
+    }
+
+    @ReceiveEvent(components = {TerritoryDistance.class})
+    public void onCreatureSpawned(OnActivatedComponent event, EntityRef creature) {
+        TerritoryDistance territoryDistance = creature.getComponent(TerritoryDistance.class);
+        territoryDistance.location = creature.getComponent(LocationComponent.class).getWorldPosition();
+        creature.saveComponent(territoryDistance);
+    }
+}


### PR DESCRIPTION
### Contains
- New `territorialCritter` behavior created as part of GCI 2019 by @BenjaminAmos

### Objective
This pull request implements territorial behaviors, where a creature is hostile to all nearby players within its territory. The creature will not leave its territory when wandering or when chasing a player. A territory is defined as a location in space along with any blocks surrounding it within a 5-block radius (this is constant as the behavior system does not appear to support comparing a variable against a variable). For now, a creature's territory is the location where they were loaded into the game from.

### Changes

- Added `territorialCritter.behavior`file and required actions/component/system