### PR TITLE
chore: Add delta prefab for floatingCube for MinionMove component

### DIFF
--- a/deltas/engine/prefabs/floatingCube.prefab
+++ b/deltas/engine/prefabs/floatingCube.prefab
@@ -1,0 +1,3 @@
+{
+  "MinionMove": {}
+}


### PR DESCRIPTION
Having the component referenced in the engine leads to ERRORs when
loading the prefab.

Related to https://github.com/MovingBlocks/Terasology/pull/3891