### PR TITLE
Add night tracker system from Metal Renegades

### DIFF
--- a/module.txt
+++ b/module.txt
@@ -1,6 +1,6 @@
 {
     "id": "Behaviors",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "author": "synopia, dkambersky",
     "displayName": "Behaviors",
     "description": "A set of behavior traits which could be applied to creatures and NPCs",

--- a/src/main/java/org/terasology/behaviors/actions/CheckNightAction.java
+++ b/src/main/java/org/terasology/behaviors/actions/CheckNightAction.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.behaviors.actions;
+
+import org.terasology.logic.behavior.BehaviorAction;
+import org.terasology.logic.behavior.core.Actor;
+import org.terasology.logic.behavior.core.BaseAction;
+import org.terasology.logic.behavior.core.BehaviorState;
+import org.terasology.behaviors.system.NightTrackerSystem;
+import org.terasology.registry.CoreRegistry;
+import org.terasology.registry.In;
+
+/**
+ * Behavior node that checks the current night status, succeeds at nighttime and fails at daytime.
+ */
+@BehaviorAction(name = "check_nighttime")
+public class CheckNightAction extends BaseAction {
+
+    @In
+    private NightTrackerSystem nightTrackerSystem;
+
+    @Override
+    public void construct(Actor actor) {
+        // TODO: Temporary fix for injection malfunction in actions, ideally remove this in the future.
+        nightTrackerSystem = CoreRegistry.get(NightTrackerSystem.class);
+    }
+
+    @Override
+    public BehaviorState modify(Actor actor, BehaviorState result) {
+        if (nightTrackerSystem.isNight()) {
+            return BehaviorState.SUCCESS;
+        }
+        return BehaviorState.FAILURE;
+    }
+
+}

--- a/src/main/java/org/terasology/behaviors/system/NightTrackerSystem.java
+++ b/src/main/java/org/terasology/behaviors/system/NightTrackerSystem.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.behaviors.system;
+
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.event.ReceiveEvent;
+import org.terasology.entitySystem.systems.BaseComponentSystem;
+import org.terasology.entitySystem.systems.RegisterMode;
+import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.registry.Share;
+import org.terasology.world.sun.OnDawnEvent;
+import org.terasology.world.sun.OnDuskEvent;
+
+/**
+ * Tracks the current night status for time-based behavior trees.
+ */
+@RegisterSystem(RegisterMode.AUTHORITY)
+@Share(value = NightTrackerSystem.class)
+public class NightTrackerSystem extends BaseComponentSystem {
+
+    // TODO: The assumption is made that this system is started with daylight, replace with a proper check on start.
+    private boolean isSunUp = true;
+
+    @ReceiveEvent
+    public void onDawnEvent(OnDawnEvent event, EntityRef entityRef) {
+        isSunUp = true;
+    }
+
+    @ReceiveEvent
+    public void onDuskEvent(OnDuskEvent event, EntityRef entityRef) {
+        isSunUp = false;
+    }
+
+    /**
+     * Returns current night status, true if the sun is down, false otherwise.
+     *
+     * @return The current night status of the world.
+     */
+    public boolean isNight() {
+        return !isSunUp;
+    }
+
+}


### PR DESCRIPTION
Introduces a system + action for tracking the current nighttime status, allowing for time-based actions. **Also pushes module version to 1.1.0.**

To use, add the `check_nighttime` node to a behavior tree. It will succeed if it is nighttime, and will fail if it's daytime.

This system is used in Terasology/MetalRenegades, and in a test character in Terasology/TutorialBehaviors.