### PR TITLE
fix: Fixes bug in direct line travel

### DIFF
--- a/src/main/java/org/terasology/minion/move/MoveToAction.java
+++ b/src/main/java/org/terasology/minion/move/MoveToAction.java
@@ -44,6 +44,7 @@ public class MoveToAction extends BaseAction {
     private static Logger logger = LoggerFactory.getLogger(MoveToAction.class);
     @Range(min = 0, max = 10)
     private float distance = 0.2f;
+    private float distanceSquared = distance*distance;
 
 
     @Override
@@ -84,7 +85,7 @@ public class MoveToAction extends BaseAction {
         float yaw = (float) Math.atan2(targetDirection.x, targetDirection.z);
         float requestedYaw = 180f + yaw * TeraMath.RAD_TO_DEG;
 
-        if((abs(targetDirection.x) < distance) && (abs(targetDirection.y) < distance) && (abs(targetDirection.z) < distance)) {
+        if(targetDirection.lengthSquared() < distanceSquared) {
             drive.set(0, 0, 0);
             reachedTarget = true;
         } else {

--- a/src/main/java/org/terasology/minion/move/MoveToAction.java
+++ b/src/main/java/org/terasology/minion/move/MoveToAction.java
@@ -27,6 +27,8 @@ import org.terasology.math.TeraMath;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.rendering.nui.properties.Range;
 
+import static org.joml.Math.abs;
+
 /**
  * <b>Properties:</b> <b>distance</b><br/>
  * <br/>
@@ -82,7 +84,7 @@ public class MoveToAction extends BaseAction {
         float yaw = (float) Math.atan2(targetDirection.x, targetDirection.z);
         float requestedYaw = 180f + yaw * TeraMath.RAD_TO_DEG;
 
-        if((targetDirection.x < distance) && (targetDirection.y < distance) && (targetDirection.z < distance)) {
+        if((abs(targetDirection.x) < distance) && (abs(targetDirection.y) < distance) && (abs(targetDirection.z) < distance)) {
             drive.set(0, 0, 0);
             reachedTarget = true;
         } else {


### PR DESCRIPTION
### Bug Fix
Bug Fix in MoveToAction node that causes characters to remain dormant even when they haven't reached the destination.

### Justification
The relevant part of code is supposed to check if the destination has been reached, and set the drive to 0, as well as return Behaviorstate.SUCCESS. However, just checking if the individual coordinates are lesser than distance (a constant set at 0.2f) is not enough. What if all the coordinates (of target direction) start out as negative negative?, Then it will always believe that the destination has been reached and never move, which is not the case. 

Thus I believe, this should be changed as so.