### PR TITLE
fix: Changed conditions for target reached

### DIFF
--- a/src/main/java/org/terasology/minion/move/MoveToAction.java
+++ b/src/main/java/org/terasology/minion/move/MoveToAction.java
@@ -31,20 +31,16 @@ import static org.joml.Math.abs;
 
 /**
  * <b>Properties:</b> <b>distance</b><br/>
- * <br/>
- * Moves the actor to the target defined by <b>MinionMoveComponent</b>.<br/>
- * <br/>
+ * <br/> Moves the actor to the target defined by <b>MinionMoveComponent</b>.<br/> <br/>
  * <b>SUCCESS</b>: when distance between actor and target is below <b>distance</b>.<br/>
  * <b>FAILURE</b>: when there is no target.<br/>
- * <br/>
- * Auto generated javadoc - modify README.markdown instead!
+ * <br/> Auto generated javadoc - modify README.markdown instead!
  */
 @BehaviorAction(name = "move_to")
 public class MoveToAction extends BaseAction {
     private static Logger logger = LoggerFactory.getLogger(MoveToAction.class);
     @Range(min = 0, max = 10)
     private float distance = 0.2f;
-    private float distanceSquared = distance*distance;
 
 
     @Override
@@ -85,7 +81,7 @@ public class MoveToAction extends BaseAction {
         float yaw = (float) Math.atan2(targetDirection.x, targetDirection.z);
         float requestedYaw = 180f + yaw * TeraMath.RAD_TO_DEG;
 
-        if(targetDirection.lengthSquared() < distanceSquared) {
+        if (abs(targetDirection.x) < distance && (abs(targetDirection.y) < 2f) && (abs(targetDirection.z) < distance)) {
             drive.set(0, 0, 0);
             reachedTarget = true;
         } else {
@@ -93,7 +89,8 @@ public class MoveToAction extends BaseAction {
             drive.set(targetDirection);
         }
 
-        CharacterMoveInputEvent wantedInput = new CharacterMoveInputEvent(0, 0, requestedYaw, drive, false, false, moveComponent.jumpMode, (long) (actor.getDelta() * 1000));
+        CharacterMoveInputEvent wantedInput = new CharacterMoveInputEvent(0, 0, requestedYaw, drive, false, false,
+                moveComponent.jumpMode, (long) (actor.getDelta() * 1000));
         actor.getEntity().send(wantedInput);
 
 


### PR DESCRIPTION
Related to #37 . 

The mentioned PR would lead to rotating gooeys. Upon testing, I noticed that the gooeys don't keep switching front and back continuously, (or rotating).

However, the `abs(targetdirection.y) < 2`  is a hardcoded thing, and can be discussed upon.