### PR TITLE
Adding Flock behavior from WildAnimalsMadness

### DIFF
--- a/assets/behaviors/common/flock.behavior
+++ b/assets/behaviors/common/flock.behavior
@@ -1,0 +1,26 @@
+{
+
+      sequence : [
+        {
+          set_flock_speed : { speedMultiplier: 0.3 }
+        },
+        {
+          animation : {
+            play: "engine:Walk.animationPool",
+            loop: "engine:Walk.animationPool"
+          }
+        },
+        flock_move,
+        {
+          animation : {
+            play: "engine:Stand.animationPool",
+            loop: "engine:Stand.animationPool"
+          }
+        },
+        {
+          sleep : {
+            time : 3
+          }
+        }
+      ]
+}

--- a/src/main/java/org/terasology/behaviors/actions/FlockMoveAction.java
+++ b/src/main/java/org/terasology/behaviors/actions/FlockMoveAction.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2019 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.behaviors.actions;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terasology.logic.behavior.BehaviorAction;
+import org.terasology.logic.behavior.core.Actor;
+import org.terasology.logic.behavior.core.BaseAction;
+import org.terasology.logic.behavior.core.BehaviorState;
+import org.terasology.logic.characters.CharacterMoveInputEvent;
+import org.terasology.logic.location.LocationComponent;
+import org.terasology.math.TeraMath;
+import org.terasology.math.geom.Vector3f;
+import org.terasology.minion.move.MinionMoveComponent;
+import org.terasology.minion.move.MoveToAction;
+import org.terasology.nui.properties.Range;
+import org.terasology.behaviors.components.FlockComponent;
+
+@BehaviorAction(name = "flock_move")
+public class FlockMoveAction extends BaseAction {
+    private static Logger logger = LoggerFactory.getLogger(MoveToAction.class);
+    @Range(min = 0, max = 10)
+    private float distance = 0.2f;
+
+
+    @Override
+    public BehaviorState modify(Actor actor, BehaviorState result) {
+        BehaviorState state = BehaviorState.FAILURE;
+        MinionMoveComponent moveComponent = actor.getComponent(MinionMoveComponent.class);
+        FlockComponent flockComponent = actor.getComponent(FlockComponent.class);
+
+
+        if ((null != moveComponent) && (null != flockComponent)) {
+            if (flockComponent.flockCentre == null) {
+                return BehaviorState.FAILURE;
+            }
+
+            moveComponent.target = flockComponent.flockCentre;
+
+            if (moveComponent.type == MinionMoveComponent.Type.DIRECT) {
+
+                boolean reachedTarget = processDirect(actor, moveComponent);
+                state = reachedTarget ? BehaviorState.SUCCESS : BehaviorState.RUNNING;
+
+            }
+
+            if (moveComponent.horizontalCollision) {
+                moveComponent.horizontalCollision = false;
+                moveComponent.jumpCooldown = 0.3f;
+            }
+            moveComponent.jumpCooldown -= actor.getDelta();
+            moveComponent.jumpMode = moveComponent.jumpCooldown > 0;
+            actor.save(moveComponent);
+
+        }
+
+        return state;
+    }
+
+    private boolean processDirect(Actor actor, MinionMoveComponent moveComponent) {
+
+        LocationComponent locationComponent = actor.getComponent(LocationComponent.class);
+        boolean reachedTarget = false;
+        Vector3f worldPos = new Vector3f(locationComponent.getWorldPosition());
+        Vector3f targetDirection = new Vector3f();
+        targetDirection.sub(moveComponent.target, worldPos);
+        Vector3f drive = new Vector3f();
+
+        float yaw = (float) Math.atan2(targetDirection.x, targetDirection.z);
+        if((targetDirection.x < distance) && (targetDirection.y < distance) && (targetDirection.z < distance)) {
+
+        //if (targetDirection.x * targetDirection.x + targetDirection.z * targetDirection.z <= distance * distance) {
+            drive.set(0, 0, 0);
+            reachedTarget = true;
+        } else {
+            targetDirection.normalize();
+            drive.set(targetDirection);
+        }
+        float requestedYaw = 180f + yaw * TeraMath.RAD_TO_DEG;
+
+        CharacterMoveInputEvent wantedInput = new CharacterMoveInputEvent(0, 0, requestedYaw, drive, false, false, moveComponent.jumpMode, (long) (actor.getDelta() * 1000));
+        actor.getEntity().send(wantedInput);
+
+
+        return reachedTarget;
+    }
+}

--- a/src/main/java/org/terasology/behaviors/actions/SetFlockSpeedAction.java
+++ b/src/main/java/org/terasology/behaviors/actions/SetFlockSpeedAction.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.behaviors.actions;
+
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.logic.behavior.BehaviorAction;
+import org.terasology.logic.behavior.GroupMindComponent;
+import org.terasology.logic.behavior.core.Actor;
+import org.terasology.logic.behavior.core.BaseAction;
+import org.terasology.logic.behavior.core.BehaviorState;
+import org.terasology.logic.characters.CharacterMovementComponent;
+import org.terasology.nui.properties.Range;
+
+@BehaviorAction(name = "set_flock_speed")
+public class SetFlockSpeedAction extends BaseAction {
+
+    @Range(max = 10f)
+    private float speedMultiplier;
+
+    @Override
+    public void construct(Actor actor) {
+        if (actor.hasComponent(GroupMindComponent.class)) {
+            GroupMindComponent hivemindComponent = actor.getComponent(GroupMindComponent.class);
+
+            if (!hivemindComponent.groupMembers.isEmpty()) {
+                for (EntityRef entityRef : hivemindComponent.groupMembers) {
+                    CharacterMovementComponent characterMovementComponent = entityRef.getComponent(CharacterMovementComponent.class);
+                    characterMovementComponent.speedMultiplier = speedMultiplier;
+                    entityRef.saveComponent(characterMovementComponent);
+                }
+            }
+        }
+    }
+
+    @Override
+    public BehaviorState modify(Actor actor, BehaviorState result) {
+        return BehaviorState.SUCCESS;
+    }
+}

--- a/src/main/java/org/terasology/behaviors/components/FlockComponent.java
+++ b/src/main/java/org/terasology/behaviors/components/FlockComponent.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.behaviors.components;
+
+import org.terasology.entitySystem.Component;
+import org.terasology.math.geom.Vector3f;
+
+public class FlockComponent implements Component {
+
+    public float speed = 5f;
+    public float searchRadius = 10f;
+    public Vector3f flockCentre = Vector3f.zero();
+    public Vector3f flockAvoid = Vector3f.zero();
+}

--- a/src/main/java/org/terasology/behaviors/system/FlockSystem.java
+++ b/src/main/java/org/terasology/behaviors/system/FlockSystem.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2019 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.behaviors.system;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terasology.entitySystem.entity.EntityManager;
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.systems.BaseComponentSystem;
+import org.terasology.entitySystem.systems.UpdateSubscriberSystem;
+import org.terasology.logic.location.LocationComponent;
+import org.terasology.math.geom.Vector3f;
+import org.terasology.registry.In;
+import org.terasology.behaviors.components.FlockComponent;
+
+import java.util.HashSet;
+import java.util.Random;
+import java.util.Set;
+
+public class FlockSystem extends BaseComponentSystem implements UpdateSubscriberSystem {
+
+    private static final Logger logger = LoggerFactory.getLogger(FindNearbyPlayersSystem.class);
+    private transient Random random = new Random();
+
+    @In
+    private EntityManager entityManager;
+
+    @Override
+    public void update(float delta) {
+
+        Set<EntityRef> flock = new HashSet<>();
+        Vector3f flockCentre = Vector3f.zero();
+        Vector3f flockAvoid = Vector3f.zero();
+        Vector3f basePosition = Vector3f.zero();
+        Vector3f baseDirection = Vector3f.zero();
+        float neighbourRadius = 1000f;
+        float groupSpeed = 0.1f;
+
+        for (EntityRef entity : entityManager.getEntitiesWith(FlockComponent.class)) {
+            flock.add(entity);
+        }
+
+        int flockSize = flock.size();
+        int baseEntityIndex = random.nextInt(flockSize - 1);
+        EntityRef baseEntity = (EntityRef)(flock.toArray()[baseEntityIndex]);
+        basePosition = baseEntity.getComponent(LocationComponent.class).getWorldPosition();
+        baseDirection = baseEntity.getComponent(LocationComponent.class).getWorldDirection();
+        neighbourRadius = baseEntity.getComponent(FlockComponent.class).searchRadius;
+
+        for(EntityRef memberCandidate : flock) {
+            Vector3f memberPosition = memberCandidate.getComponent(LocationComponent.class).getWorldPosition();
+            float distance = Vector3f.distance(memberPosition,baseDirection);
+            if(distance <= neighbourRadius) {
+                flockCentre.setX(flockCentre.getX() + memberPosition.getX());
+                flockCentre.setY(flockCentre.getY() + memberPosition.getY());
+                flockCentre.setZ(flockCentre.getZ() + memberPosition.getZ());
+                if(distance < 1f) {
+                    flockAvoid.setX(flockAvoid.getX() + basePosition.getX() - memberPosition.getX());
+                    flockAvoid.setY(flockAvoid.getY() + basePosition.getY() - memberPosition.getY());
+                    flockAvoid.setZ(flockAvoid.getZ() + basePosition.getZ() - memberPosition.getZ());
+                }
+                groupSpeed += memberCandidate.getComponent(FlockComponent.class).speed;
+            }
+        }
+
+        flockCentre.setX(flockCentre.getX()/flockSize);
+        flockCentre.setY(flockCentre.getY()/flockSize);
+        flockCentre.setZ(flockCentre.getZ()/flockSize);
+
+        for(EntityRef member : flock) {
+            FlockComponent flockComponent  = member.getComponent(FlockComponent.class);
+            flockComponent.speed = groupSpeed;
+            flockComponent.flockCentre = flockCentre;
+            flockComponent.flockAvoid = flockAvoid;
+            member.saveComponent(flockComponent);
+        }
+
+    }
+}


### PR DESCRIPTION
Moving the Flock behavior from WildAnimalsMadness.

How to test:

- Assign the `flock` behavior to an existing WildAnimals prefab (or a creature prefab from any module that depends on Behaviors)
- Spawn a number of creatures (n>3, preferably). you should see the creatures flocking.