### PR TITLE
fix: fleeing entities must have a CharacterMovement component

### DIFF
--- a/src/main/java/org/terasology/behaviors/system/BehaviorsEventSystem.java
+++ b/src/main/java/org/terasology/behaviors/system/BehaviorsEventSystem.java
@@ -28,7 +28,7 @@ public class BehaviorsEventSystem extends BaseComponentSystem {
     /**
      * Make an entity with the a {@link FleeOnHitComponent} flee from the instigator when being damaged.
      *
-     * @param event
+     * @param event the {@link OnDamageEvent} notifying about the entity having taken damage
      * @param entity the entity being damaged
      * @param fleeOnHitComponent only entities with this component flee if they take damage
      * @param characterMovementComponent a fleeing entity needs a character movement component to allow it to actually flee from the

--- a/src/main/java/org/terasology/behaviors/system/BehaviorsEventSystem.java
+++ b/src/main/java/org/terasology/behaviors/system/BehaviorsEventSystem.java
@@ -13,9 +13,8 @@ import org.terasology.engine.entitySystem.systems.BaseComponentSystem;
 import org.terasology.engine.entitySystem.systems.RegisterMode;
 import org.terasology.engine.entitySystem.systems.RegisterSystem;
 import org.terasology.engine.logic.characters.CharacterMovementComponent;
-import org.terasology.module.health.events.OnDamagedEvent;
 import org.terasology.engine.registry.In;
-
+import org.terasology.module.health.events.OnDamagedEvent;
 
 /*
  * Listens for events relevant to this module's animals and responds as necessary
@@ -26,20 +25,31 @@ public class BehaviorsEventSystem extends BaseComponentSystem {
     @In
     private Time time;
 
-    @ReceiveEvent(components = FleeOnHitComponent.class)
-    public void onDamage(OnDamagedEvent event, EntityRef entity) {
+    /**
+     * Make an entity with the a {@link FleeOnHitComponent} flee from the instigator when being damaged.
+     *
+     * @param event
+     * @param entity the entity being damaged
+     * @param fleeOnHitComponent only entities with this component flee if they take damage
+     * @param characterMovementComponent a fleeing entity needs a character movement component to allow it to actually flee from the
+     *         attacker
+     */
+    @ReceiveEvent
+    public void onDamage(OnDamagedEvent event, EntityRef entity,
+                         FleeOnHitComponent fleeOnHitComponent,
+                         CharacterMovementComponent characterMovementComponent) {
 
-        // Make entity flee
-        FleeingComponent fleeingComponent = new FleeingComponent();
-        fleeingComponent.instigator = event.getInstigator();
-        fleeingComponent.minDistance = entity.getComponent(FleeOnHitComponent.class).minDistance;
-        entity.addOrSaveComponent(fleeingComponent);
+        // Make entity flee (update existing FleeingComponent or add fresh component if not present)
+        entity.upsertComponent(FleeingComponent.class, maybeFleeingComponent -> {
+            FleeingComponent fleeingComponent = maybeFleeingComponent.orElse(new FleeingComponent());
+            fleeingComponent.instigator = event.getInstigator();
+            fleeingComponent.minDistance = fleeOnHitComponent.minDistance;
+            return fleeingComponent;
+        });
 
         // Increase speed by multiplier factor
-        CharacterMovementComponent characterMovementComponent = entity.getComponent(CharacterMovementComponent.class);
-        characterMovementComponent.speedMultiplier = entity.getComponent(FleeOnHitComponent.class).speedMultiplier;
-        entity.addOrSaveComponent(characterMovementComponent);
-
+        characterMovementComponent.speedMultiplier = fleeOnHitComponent.speedMultiplier;
+        entity.saveComponent(characterMovementComponent);
     }
 
     /**


### PR DESCRIPTION
**Problem:** An entity with a death animation may already be stripped off its CharacterMovementComponent when receiving additional damage. This may cause an NPE when accessing the component without guarding check.

**Solution:** Require the CharacterMovementComponent in the event handler to ensure that it is present. Skip the event handler if the component is not present, as fleeing without character movement does make much sense anyways.
