### PR TITLE
feat: simulate gravity-less movement, add movement plugin for falling

### DIFF
--- a/src/main/java/org/terasology/module/behaviors/plugin/FallingMovementPlugin.java
+++ b/src/main/java/org/terasology/module/behaviors/plugin/FallingMovementPlugin.java
@@ -1,0 +1,63 @@
+// Copyright 2022 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.terasology.module.behaviors.plugin;
+
+import org.joml.Vector3f;
+import org.joml.Vector3fc;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terasology.engine.core.Time;
+import org.terasology.engine.entitySystem.entity.EntityRef;
+import org.terasology.engine.logic.characters.CharacterMoveInputEvent;
+import org.terasology.engine.logic.characters.CharacterMovementComponent;
+import org.terasology.engine.logic.characters.MovementMode;
+import org.terasology.engine.logic.characters.events.SetMovementModeEvent;
+import org.terasology.engine.logic.location.LocationComponent;
+import org.terasology.engine.world.WorldProvider;
+import org.terasology.flexiblepathfinding.plugins.JPSPlugin;
+import org.terasology.flexiblepathfinding.plugins.basic.FallingPlugin;
+
+public class FallingMovementPlugin extends MovementPlugin {
+
+    private static final Logger logger = LoggerFactory.getLogger(FallingMovementPlugin.class);
+
+    public FallingMovementPlugin(WorldProvider world, Time time) {
+        super(world, time);
+    }
+
+    public FallingMovementPlugin() {
+        super();
+    }
+
+    @Override
+    public JPSPlugin getJpsPlugin(EntityRef entity) {
+        CharacterMovementComponent component = entity.getComponent(CharacterMovementComponent.class);
+        return new FallingPlugin(getWorld(), component.radius * 2.0f, component.height);
+    }
+
+    @Override
+    public CharacterMoveInputEvent move(EntityRef entity, Vector3fc dest, int sequence) {
+        if (logger.isDebugEnabled()) {
+            logger.debug("--> [{}] {} move: {} - current: {} - destination: {}",
+                    entity.getId(),
+                    String.format("%03d", sequence),
+                    "falling",
+                    entity.getComponent(LocationComponent.class).getWorldPosition(new Vector3f()),
+                    dest);
+        }
+        CharacterMovementComponent movement = entity.getComponent(CharacterMovementComponent.class);
+        // The other basic plugins assume that the entity is not affected by gravity. However, in this specific case of falling,
+        // we actually want gravity on the NPC. Therefore, we need to make sure that we're in a movement mode that has non-zero
+        // gravity factor, e.g., WALKING.
+        if (movement.mode != MovementMode.WALKING) {
+            entity.send(new SetMovementModeEvent(MovementMode.WALKING));
+        }
+        //TODO: ensure that 'dest' is below the entity's location? What should we do in case we missed the 'dest'?
+        Vector3f delta = getDelta(entity, dest);
+        float yaw = getYaw(delta);
+        long dt = getTime().getGameDeltaInMs();
+
+        return new CharacterMoveInputEvent(sequence, 0, yaw, delta, false, false, false, dt);
+    }
+}

--- a/src/main/java/org/terasology/module/behaviors/plugin/LeapingMovementPlugin.java
+++ b/src/main/java/org/terasology/module/behaviors/plugin/LeapingMovementPlugin.java
@@ -8,6 +8,8 @@ import org.terasology.engine.core.Time;
 import org.terasology.engine.entitySystem.entity.EntityRef;
 import org.terasology.engine.logic.characters.CharacterMoveInputEvent;
 import org.terasology.engine.logic.characters.CharacterMovementComponent;
+import org.terasology.engine.logic.characters.MovementMode;
+import org.terasology.engine.logic.characters.events.SetMovementModeEvent;
 import org.terasology.engine.world.WorldProvider;
 import org.terasology.flexiblepathfinding.plugins.JPSPlugin;
 import org.terasology.flexiblepathfinding.plugins.basic.LeapingPlugin;
@@ -34,6 +36,11 @@ public class LeapingMovementPlugin extends MovementPlugin {
         long dt = getTime().getGameDeltaInMs();
 
         CharacterMovementComponent movement = entity.getComponent(CharacterMovementComponent.class);
+        // The underlying WalkingPlugin assumes that entities are not affected by gravity.
+        // To simulate this, we'll use the FLYING movement mode for all entities when moving them with this plugin.
+        if (movement.mode != MovementMode.FLYING) {
+            entity.send(new SetMovementModeEvent(MovementMode.FLYING));
+        }
         return new CharacterMoveInputEvent(sequence, 0, yaw, delta, false, false, true, dt);
     }
 }

--- a/src/main/java/org/terasology/module/behaviors/plugin/WalkingMovementPlugin.java
+++ b/src/main/java/org/terasology/module/behaviors/plugin/WalkingMovementPlugin.java
@@ -8,6 +8,8 @@ import org.terasology.engine.core.Time;
 import org.terasology.engine.entitySystem.entity.EntityRef;
 import org.terasology.engine.logic.characters.CharacterMoveInputEvent;
 import org.terasology.engine.logic.characters.CharacterMovementComponent;
+import org.terasology.engine.logic.characters.MovementMode;
+import org.terasology.engine.logic.characters.events.SetMovementModeEvent;
 import org.terasology.engine.world.WorldProvider;
 import org.terasology.flexiblepathfinding.plugins.JPSPlugin;
 import org.terasology.flexiblepathfinding.plugins.basic.WalkingPlugin;
@@ -34,6 +36,12 @@ public class WalkingMovementPlugin extends MovementPlugin {
         long dt = getTime().getGameDeltaInMs();
 
         CharacterMovementComponent movement = entity.getComponent(CharacterMovementComponent.class);
+        // The underlying WalkingPlugin assumes that entities are not affected by gravity.
+        // To simulate this, we'll use the FLYING movement mode for all entities when moving them with this plugin.
+        if (movement.mode != MovementMode.FLYING) {
+            entity.send(new SetMovementModeEvent(MovementMode.FLYING));
+        }
+
         return new CharacterMoveInputEvent(sequence, 0, yaw, delta, false, false, dt);
     }
 }

--- a/src/main/java/org/terasology/module/behaviors/systems/PluginSystem.java
+++ b/src/main/java/org/terasology/module/behaviors/systems/PluginSystem.java
@@ -18,6 +18,7 @@ import org.terasology.engine.registry.Share;
 import org.terasology.engine.world.WorldProvider;
 import org.terasology.module.behaviors.components.MinionMoveComponent;
 import org.terasology.module.behaviors.plugin.CompositeMovementPlugin;
+import org.terasology.module.behaviors.plugin.FallingMovementPlugin;
 import org.terasology.module.behaviors.plugin.FlyingMovementPlugin;
 import org.terasology.module.behaviors.plugin.LeapingMovementPlugin;
 import org.terasology.module.behaviors.plugin.MovementPlugin;
@@ -48,6 +49,7 @@ public class PluginSystem extends BaseComponentSystem {
         registerMovementPlugin("leaping", (entity) -> new LeapingMovementPlugin(worldProvider, time));
         registerMovementPlugin("flying", (entity) -> new FlyingMovementPlugin(worldProvider, time));
         registerMovementPlugin("swimming", (entity) -> new SwimmingMovementPlugin(worldProvider, time));
+        registerMovementPlugin("falling", (entity) -> new FallingMovementPlugin(worldProvider, time));
     }
 
     public void registerMovementPlugin(String name, Function<EntityRef, MovementPlugin> supplier) {


### PR DESCRIPTION
Extracted from https://github.com/Terasology/Behaviors/pull/92

We noticed that the underlying [`FlexiblePathfinding WalkingPlugin`](https://github.com/Terasology/FlexiblePathfinding/blob/develop/src/main/java/org/terasology/flexiblepathfinding/plugins/basic/WalkingPlugin.java) assumes that entities are not affected by gravity. To simulate this, we'll use the FLYING movement mode for all entities when moving them with the `WalkingMovementPlugin` or `LeapingMovementPlugin`.

In addition, this PR adds the `FallingMovementPlugin` for downwards movements. Here, we actually want gravity on the NPC, so this plugin will use the WALKING movement mode.