### PR TITLE
chore: apply workaround for @In malfunction in actions

### DIFF
--- a/assets/prefabs/behaviorNodes/jump.prefab
+++ b/assets/prefabs/behaviorNodes/jump.prefab
@@ -1,12 +1,12 @@
 {
-    "BehaviorNode" : {
-        "action"      : "jump",
-        "name"      : "jump",
-        "displayName"      : "Jump",
-        "category"  : "moving",
-        "shape"     : "rect",
-        "color"     : [0.7, 0.7, 0.7, 255],
-        "description": "Trigger a single jump into the air.\nSUCCESS: when the actor is grounded after the jump again.",
-        "textColor" : [  0,   0,   0, 255]
-    }
+  "BehaviorNode": {
+    "action": "jump",
+    "name": "jump",
+    "displayName": "Jump",
+    "category": "moving",
+    "shape": "rect",
+    "color": [0.7, 0.7, 0.7, 255],
+    "description": "Trigger a single jump into the air.\nSUCCESS: when the actor is grounded after the jump again.",
+    "textColor": [0, 0, 0, 255]
+  }
 }

--- a/assets/prefabs/behaviorNodes/setTargetLocalPlayer.prefab
+++ b/assets/prefabs/behaviorNodes/setTargetLocalPlayer.prefab
@@ -1,12 +1,12 @@
 {
-    "BehaviorNode" : {
-        "action"      : "set_target_local_player",
-        "name"      : "set_target_local_player",
-        "displayName"      : "Set Target To Local Player",
-        "category"  : "moving",
-        "shape"     : "rect",
-        "description": "Set MinionMoveComponent.target to the block below local player.\nAlways returns SUCCESS.",
-        "color"     : [0.7, 0.7, 0.7, 255],
-        "textColor" : [  0,   0,   0, 255]
-    }
+  "BehaviorNode": {
+    "action": "set_target_local_player",
+    "name": "set_target_local_player",
+    "displayName": "Set Target To Local Player",
+    "category": "moving",
+    "shape": "rect",
+    "description": "Set MinionMoveComponent.target to the block below local player.\nAlways returns SUCCESS.",
+    "color": [0.7, 0.7, 0.7, 255],
+    "textColor": [0, 0, 0, 255]
+  }
 }

--- a/assets/prefabs/behaviorNodes/setTargetToNearbyBlock.prefab
+++ b/assets/prefabs/behaviorNodes/setTargetToNearbyBlock.prefab
@@ -1,12 +1,12 @@
 {
-    "BehaviorNode" : {
-        "action"      : "set_target_nearby_block",
-        "name"      : "set_target_nearby_block",
-        "displayName"      : "Set target to a random nearby block",
-        "category"  : "moving",
-        "shape"     : "rect",
-        "description": "Set MinionMoveComponent's target to a nearby block.\nReturns always SUCCESS",
-        "color"     : [0.7, 0.7, 0.7, 255],
-        "textColor" : [  0,   0,   0, 255]
-    }
+  "BehaviorNode": {
+    "action": "set_target_nearby_block",
+    "name": "set_target_nearby_block",
+    "displayName": "Set target to a random nearby block",
+    "category": "moving",
+    "shape": "rect",
+    "description": "Set MinionMoveComponent's target to a nearby block.\nReturns always SUCCESS",
+    "color": [0.7, 0.7, 0.7, 255],
+    "textColor": [0, 0, 0, 255]
+  }
 }

--- a/assets/prefabs/jobRemoveBlock.prefab
+++ b/assets/prefabs/jobRemoveBlock.prefab
@@ -1,20 +1,20 @@
 {
-    "parent" : "engine:iconItem",
+  "parent": "engine:iconItem",
   "DisplayName": {
     "name": "Remove Block"
   },
-    "Item" : {
-        "icon" : "engine:items#removeBlockJob",
-		"usage" : "ON_BLOCK"
-    },
-  	"PlaySoundAction" : {
-    	"sounds" : "engine:click"
-  	},
-    "Work" : {
-        "workType" : "Behaviors:removeBlock"
-    },
-    "BlockSelection" : {
-        "shouldRender" : true
-    },
-    "OnItemActivateSelection" : {}
+  "Item": {
+    "icon": "engine:items#removeBlockJob",
+    "usage": "ON_BLOCK"
+  },
+  "PlaySoundAction": {
+    "sounds": "engine:click"
+  },
+  "Work": {
+    "workType": "Behaviors:removeBlock"
+  },
+  "BlockSelection": {
+    "shouldRender": true
+  },
+  "OnItemActivateSelection": {}
 }

--- a/src/main/java/org/terasology/module/behaviors/actions/CheckAttackStopAction.java
+++ b/src/main/java/org/terasology/module/behaviors/actions/CheckAttackStopAction.java
@@ -91,10 +91,7 @@ public class CheckAttackStopAction extends BaseAction {
         if (locationComponent == null) {
             return true;
         }
-        if (locationComponent.getWorldPosition(new Vector3f()).distanceSquared(actorPosition) <= maxDistanceSquared) {
-            return false;
-        }
-        return true;
+        return !(locationComponent.getWorldPosition(new Vector3f()).distanceSquared(actorPosition) <= maxDistanceSquared);
     }
 
 }

--- a/src/main/java/org/terasology/module/behaviors/actions/CheckNightAction.java
+++ b/src/main/java/org/terasology/module/behaviors/actions/CheckNightAction.java
@@ -21,7 +21,7 @@ public class CheckNightAction extends BaseAction {
 
     @Override
     public void construct(Actor actor) {
-        // TODO: Temporary fix for injection malfunction in actions, remove as soon as injection malfunction in actions is fixed.
+        // TODO: Temporary fix for injection malfunction, remove once https://github.com/MovingBlocks/Terasology/issues/5004 is fixed.
         if (nightTrackerSystem == null) {
             nightTrackerSystem = CoreRegistry.get(NightTrackerSystem.class);
         }

--- a/src/main/java/org/terasology/module/behaviors/actions/CheckNightAction.java
+++ b/src/main/java/org/terasology/module/behaviors/actions/CheckNightAction.java
@@ -21,8 +21,10 @@ public class CheckNightAction extends BaseAction {
 
     @Override
     public void construct(Actor actor) {
-        // TODO: Temporary fix for injection malfunction in actions, ideally remove this in the future.
-        nightTrackerSystem = CoreRegistry.get(NightTrackerSystem.class);
+        // TODO: Temporary fix for injection malfunction in actions, remove as soon as injection malfunction in actions is fixed.
+        if (nightTrackerSystem == null) {
+            nightTrackerSystem = CoreRegistry.get(NightTrackerSystem.class);
+        }
     }
 
     @Override

--- a/src/main/java/org/terasology/module/behaviors/actions/FindPathToNode.java
+++ b/src/main/java/org/terasology/module/behaviors/actions/FindPathToNode.java
@@ -47,6 +47,7 @@ public class FindPathToNode extends BaseAction {
 
     @Override
     public void construct(Actor actor) {
+        // TODO: Temporary fix for injection malfunction in actions, remove as soon as injection malfunction in actions is fixed.
         if (pathfinderSystem == null) {
             pathfinderSystem = CoreRegistry.get(PathfinderSystem.class);
         }

--- a/src/main/java/org/terasology/module/behaviors/actions/FindPathToNode.java
+++ b/src/main/java/org/terasology/module/behaviors/actions/FindPathToNode.java
@@ -47,7 +47,7 @@ public class FindPathToNode extends BaseAction {
 
     @Override
     public void construct(Actor actor) {
-        // TODO: Temporary fix for injection malfunction in actions, remove as soon as injection malfunction in actions is fixed.
+        // TODO: Temporary fix for injection malfunction, remove once https://github.com/MovingBlocks/Terasology/issues/5004 is fixed.
         if (pathfinderSystem == null) {
             pathfinderSystem = CoreRegistry.get(PathfinderSystem.class);
         }

--- a/src/main/java/org/terasology/module/behaviors/actions/FollowPlayerWithinRangeAction.java
+++ b/src/main/java/org/terasology/module/behaviors/actions/FollowPlayerWithinRangeAction.java
@@ -32,7 +32,7 @@ public class FollowPlayerWithinRangeAction extends BaseAction {
 
     @Override
     public void construct(Actor actor) {
-        // TODO: Temporary fix for injection malfunction in actions, remove as soon as injection malfunction in actions is fixed.
+        // TODO: Temporary fix for injection malfunction, remove once https://github.com/MovingBlocks/Terasology/issues/5004 is fixed.
         if (entityManager == null) {
             entityManager = CoreRegistry.get(EntityManager.class);
         }

--- a/src/main/java/org/terasology/module/behaviors/actions/FollowPlayerWithinRangeAction.java
+++ b/src/main/java/org/terasology/module/behaviors/actions/FollowPlayerWithinRangeAction.java
@@ -4,6 +4,7 @@ package org.terasology.module.behaviors.actions;
 
 import com.google.common.collect.Lists;
 import org.joml.Vector3f;
+import org.terasology.engine.registry.CoreRegistry;
 import org.terasology.module.behaviors.components.FollowComponent;
 import org.terasology.engine.entitySystem.entity.EntityManager;
 import org.terasology.engine.entitySystem.entity.EntityRef;
@@ -15,6 +16,7 @@ import org.terasology.engine.logic.characters.AliveCharacterComponent;
 import org.terasology.engine.logic.location.LocationComponent;
 import org.terasology.engine.network.ClientComponent;
 import org.terasology.engine.registry.In;
+import org.terasology.module.behaviors.systems.PluginSystem;
 import org.terasology.nui.properties.Range;
 
 import java.util.List;
@@ -27,6 +29,14 @@ public class FollowPlayerWithinRangeAction extends BaseAction {
 
     @In
     private EntityManager entityManager;
+
+    @Override
+    public void construct(Actor actor) {
+        // TODO: Temporary fix for injection malfunction in actions, remove as soon as injection malfunction in actions is fixed.
+        if (entityManager == null) {
+            entityManager = CoreRegistry.get(EntityManager.class);
+        }
+    }
 
     @Override
     public BehaviorState modify(Actor actor, BehaviorState result) {

--- a/src/main/java/org/terasology/module/behaviors/actions/MoveToAction.java
+++ b/src/main/java/org/terasology/module/behaviors/actions/MoveToAction.java
@@ -43,12 +43,17 @@ public class MoveToAction extends BaseAction {
 
     @Override
     public void construct(Actor actor) {
+        // TODO: Temporary fix for injection malfunction in actions, remove as soon as injection malfunction in actions is fixed.
+        if (time == null) {
+            time = CoreRegistry.get(Time.class);
+        }
         if (world == null) {
             world = CoreRegistry.get(WorldProvider.class);
         }
         if (pluginSystem == null) {
             pluginSystem = CoreRegistry.get(PluginSystem.class);
         }
+
         MinionMoveComponent minionMoveComponent = actor.getComponent(MinionMoveComponent.class);
         minionMoveComponent.sequenceNumber = 0;
         actor.save(minionMoveComponent);

--- a/src/main/java/org/terasology/module/behaviors/actions/MoveToAction.java
+++ b/src/main/java/org/terasology/module/behaviors/actions/MoveToAction.java
@@ -43,7 +43,7 @@ public class MoveToAction extends BaseAction {
 
     @Override
     public void construct(Actor actor) {
-        // TODO: Temporary fix for injection malfunction in actions, remove as soon as injection malfunction in actions is fixed.
+        // TODO: Temporary fix for injection malfunction, remove once https://github.com/MovingBlocks/Terasology/issues/5004 is fixed.
         if (time == null) {
             time = CoreRegistry.get(Time.class);
         }

--- a/src/main/java/org/terasology/module/behaviors/actions/NearbyBlockRestricted.java
+++ b/src/main/java/org/terasology/module/behaviors/actions/NearbyBlockRestricted.java
@@ -14,6 +14,7 @@ import org.terasology.engine.logic.behavior.core.Actor;
 import org.terasology.engine.logic.behavior.core.BaseAction;
 import org.terasology.engine.logic.behavior.core.BehaviorState;
 import org.terasology.engine.logic.location.LocationComponent;
+import org.terasology.engine.registry.CoreRegistry;
 import org.terasology.engine.registry.In;
 import org.terasology.engine.world.block.BlockArea;
 import org.terasology.engine.world.block.BlockRegion;
@@ -52,6 +53,11 @@ public class NearbyBlockRestricted extends BaseAction {
 
     @Override
     public void construct(Actor actor) {
+        // TODO: Temporary fix for injection malfunction in actions, remove as soon as injection malfunction in actions is fixed.
+        if (movementPluginSystem == null) {
+            movementPluginSystem = CoreRegistry.get(PluginSystem.class);
+        }
+
         if (!actor.hasComponent(StrayRestrictionComponent.class)) {
             logger.warn("Actor used behavior node set_target_nearby_block_restricted, but doesn't have a StrayRestrictionComponent!");
             return;

--- a/src/main/java/org/terasology/module/behaviors/actions/NearbyBlockRestricted.java
+++ b/src/main/java/org/terasology/module/behaviors/actions/NearbyBlockRestricted.java
@@ -53,7 +53,7 @@ public class NearbyBlockRestricted extends BaseAction {
 
     @Override
     public void construct(Actor actor) {
-        // TODO: Temporary fix for injection malfunction in actions, remove as soon as injection malfunction in actions is fixed.
+        // TODO: Temporary fix for injection malfunction, remove once https://github.com/MovingBlocks/Terasology/issues/5004 is fixed.
         if (movementPluginSystem == null) {
             movementPluginSystem = CoreRegistry.get(PluginSystem.class);
         }

--- a/src/main/java/org/terasology/module/behaviors/actions/PlayMusicAction.java
+++ b/src/main/java/org/terasology/module/behaviors/actions/PlayMusicAction.java
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.module.behaviors.actions;
 
+import org.terasology.engine.registry.CoreRegistry;
 import org.terasology.gestalt.assets.ResourceUrn;
 import org.terasology.gestalt.assets.management.AssetManager;
 import org.terasology.engine.audio.AudioEndListener;
@@ -13,6 +14,7 @@ import org.terasology.engine.logic.behavior.core.BaseAction;
 import org.terasology.engine.logic.behavior.core.BehaviorState;
 import org.terasology.engine.registry.In;
 import org.terasology.gestalt.module.sandbox.API;
+import org.terasology.module.behaviors.systems.PluginSystem;
 import org.terasology.nui.properties.OneOf;
 import org.terasology.nui.properties.Range;
 
@@ -33,8 +35,15 @@ public class PlayMusicAction extends BaseAction {
 
     @Override
     public void construct(Actor actor) {
-        if (musicUrn != null) {
+        // TODO: Temporary fix for injection malfunction in actions, remove as soon as injection malfunction in actions is fixed.
+        if (audioManager == null) {
+            audioManager = CoreRegistry.get(AudioManager.class);
+        }
+        if (assetManager == null) {
+            assetManager = CoreRegistry.get(AssetManager.class);
+        }
 
+        if (musicUrn != null) {
             StreamingSound snd = assetManager.getAsset(musicUrn, StreamingSound.class).orElse(null);
 
             if (snd != null) {

--- a/src/main/java/org/terasology/module/behaviors/actions/PlayMusicAction.java
+++ b/src/main/java/org/terasology/module/behaviors/actions/PlayMusicAction.java
@@ -35,7 +35,7 @@ public class PlayMusicAction extends BaseAction {
 
     @Override
     public void construct(Actor actor) {
-        // TODO: Temporary fix for injection malfunction in actions, remove as soon as injection malfunction in actions is fixed.
+        // TODO: Temporary fix for injection malfunction, remove once https://github.com/MovingBlocks/Terasology/issues/5004 is fixed.
         if (audioManager == null) {
             audioManager = CoreRegistry.get(AudioManager.class);
         }

--- a/src/main/java/org/terasology/module/behaviors/actions/PlaySoundAction.java
+++ b/src/main/java/org/terasology/module/behaviors/actions/PlaySoundAction.java
@@ -3,6 +3,7 @@
 package org.terasology.module.behaviors.actions;
 
 import org.joml.Vector3f;
+import org.terasology.engine.registry.CoreRegistry;
 import org.terasology.gestalt.assets.ResourceUrn;
 import org.terasology.gestalt.assets.management.AssetManager;
 import org.terasology.engine.audio.AudioEndListener;
@@ -36,10 +37,16 @@ public class PlaySoundAction extends BaseAction {
 
     @Override
     public void construct(Actor actor) {
+        // TODO: Temporary fix for injection malfunction in actions, remove as soon as injection malfunction in actions is fixed.
+        if (audioManager == null) {
+            audioManager = CoreRegistry.get(AudioManager.class);
+        }
+        if (assetManager == null) {
+            assetManager = CoreRegistry.get(AssetManager.class);
+        }
+
         if (soundUrn != null) {
-
             StaticSound snd = assetManager.getAsset(soundUrn, StaticSound.class).orElse(null);
-
 
             if (snd != null) {
                 if (actor.hasComponent(LocationComponent.class)) {

--- a/src/main/java/org/terasology/module/behaviors/actions/PlaySoundAction.java
+++ b/src/main/java/org/terasology/module/behaviors/actions/PlaySoundAction.java
@@ -37,7 +37,7 @@ public class PlaySoundAction extends BaseAction {
 
     @Override
     public void construct(Actor actor) {
-        // TODO: Temporary fix for injection malfunction in actions, remove as soon as injection malfunction in actions is fixed.
+        // TODO: Temporary fix for injection malfunction, remove once https://github.com/MovingBlocks/Terasology/issues/5004 is fixed.
         if (audioManager == null) {
             audioManager = CoreRegistry.get(AudioManager.class);
         }

--- a/src/main/java/org/terasology/module/behaviors/actions/SetTargetToNearbyBlockAwayFromInstigatorAction.java
+++ b/src/main/java/org/terasology/module/behaviors/actions/SetTargetToNearbyBlockAwayFromInstigatorAction.java
@@ -42,7 +42,7 @@ public class SetTargetToNearbyBlockAwayFromInstigatorAction extends BaseAction {
 
     @Override
     public void construct(Actor actor) {
-        // TODO: Temporary fix for injection malfunction in actions, remove as soon as injection malfunction in actions is fixed.
+        // TODO: Temporary fix for injection malfunction, remove once https://github.com/MovingBlocks/Terasology/issues/5004 is fixed.
         if (movementPluginSystem == null) {
             movementPluginSystem = CoreRegistry.get(PluginSystem.class);
         }

--- a/src/main/java/org/terasology/module/behaviors/actions/SetTargetToNearbyBlockAwayFromInstigatorAction.java
+++ b/src/main/java/org/terasology/module/behaviors/actions/SetTargetToNearbyBlockAwayFromInstigatorAction.java
@@ -42,6 +42,7 @@ public class SetTargetToNearbyBlockAwayFromInstigatorAction extends BaseAction {
 
     @Override
     public void construct(Actor actor) {
+        // TODO: Temporary fix for injection malfunction in actions, remove as soon as injection malfunction in actions is fixed.
         if (movementPluginSystem == null) {
             movementPluginSystem = CoreRegistry.get(PluginSystem.class);
         }

--- a/src/main/java/org/terasology/module/behaviors/actions/SetTargetToNearbyBlockNode.java
+++ b/src/main/java/org/terasology/module/behaviors/actions/SetTargetToNearbyBlockNode.java
@@ -37,6 +37,7 @@ public class SetTargetToNearbyBlockNode extends BaseAction {
 
     @Override
     public void construct(Actor actor) {
+        // TODO: Temporary fix for injection malfunction in actions, remove as soon as injection malfunction in actions is fixed.
         if (movementPluginSystem == null) {
             movementPluginSystem = CoreRegistry.get(PluginSystem.class);
         }

--- a/src/main/java/org/terasology/module/behaviors/actions/SetTargetToNearbyBlockNode.java
+++ b/src/main/java/org/terasology/module/behaviors/actions/SetTargetToNearbyBlockNode.java
@@ -37,7 +37,7 @@ public class SetTargetToNearbyBlockNode extends BaseAction {
 
     @Override
     public void construct(Actor actor) {
-        // TODO: Temporary fix for injection malfunction in actions, remove as soon as injection malfunction in actions is fixed.
+        // TODO: Temporary fix for injection malfunction, remove once https://github.com/MovingBlocks/Terasology/issues/5004 is fixed.
         if (movementPluginSystem == null) {
             movementPluginSystem = CoreRegistry.get(PluginSystem.class);
         }

--- a/src/main/java/org/terasology/module/behaviors/actions/SetTargetToNearbyPlayer.java
+++ b/src/main/java/org/terasology/module/behaviors/actions/SetTargetToNearbyPlayer.java
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.terasology.module.behaviors.actions;
 
+import org.terasology.engine.registry.CoreRegistry;
 import org.terasology.module.behaviors.components.AttackOnHitComponent;
 import org.terasology.module.behaviors.components.FindNearbyPlayersComponent;
 import org.terasology.module.behaviors.components.FollowComponent;
@@ -11,11 +12,20 @@ import org.terasology.engine.logic.behavior.core.Actor;
 import org.terasology.engine.logic.behavior.core.BaseAction;
 import org.terasology.engine.logic.behavior.core.BehaviorState;
 import org.terasology.engine.registry.In;
+import org.terasology.module.behaviors.systems.PluginSystem;
 
 @BehaviorAction(name = "set_target_nearby_player")
 public class SetTargetToNearbyPlayer extends BaseAction {
     @In
     private Time time;
+
+    @Override
+    public void construct(Actor actor) {
+        // TODO: Temporary fix for injection malfunction in actions, remove as soon as injection malfunction in actions is fixed.
+        if (time == null) {
+            time = CoreRegistry.get(Time.class);
+        }
+    }
 
     @Override
     public BehaviorState modify(Actor actor, BehaviorState result) {

--- a/src/main/java/org/terasology/module/behaviors/actions/SetTargetToNearbyPlayer.java
+++ b/src/main/java/org/terasology/module/behaviors/actions/SetTargetToNearbyPlayer.java
@@ -21,7 +21,7 @@ public class SetTargetToNearbyPlayer extends BaseAction {
 
     @Override
     public void construct(Actor actor) {
-        // TODO: Temporary fix for injection malfunction in actions, remove as soon as injection malfunction in actions is fixed.
+        // TODO: Temporary fix for injection malfunction, remove once https://github.com/MovingBlocks/Terasology/issues/5004 is fixed.
         if (time == null) {
             time = CoreRegistry.get(Time.class);
         }

--- a/src/main/java/org/terasology/module/behaviors/actions/ValidatePath.java
+++ b/src/main/java/org/terasology/module/behaviors/actions/ValidatePath.java
@@ -7,6 +7,7 @@ import org.terasology.engine.logic.behavior.BehaviorAction;
 import org.terasology.engine.logic.behavior.core.Actor;
 import org.terasology.engine.logic.behavior.core.BaseAction;
 import org.terasology.engine.logic.behavior.core.BehaviorState;
+import org.terasology.engine.registry.CoreRegistry;
 import org.terasology.engine.registry.In;
 import org.terasology.flexiblepathfinding.PathfinderSystem;
 import org.terasology.flexiblepathfinding.plugins.JPSPlugin;
@@ -17,7 +18,7 @@ import org.terasology.module.behaviors.systems.PluginSystem;
 import java.util.List;
 
 /**
- * Validates the entity's current path for walkability (according to the pathfinding plugin its using)
+ * Validates the entity's current path for walkability (according to the pathfinding plugin it's using)
  * <p>
  * SUCCESS: when there are no unwalkable waypoints
  * <p>
@@ -34,6 +35,14 @@ public class ValidatePath extends BaseAction {
     private PluginSystem pluginSystem;
     @In
     private MinionMoveSystem minionMoveSystem;
+
+    @Override
+    public void construct(Actor actor) {
+        // TODO: Temporary fix for injection malfunction in actions, remove as soon as injection malfunction in actions is fixed.
+        if (pluginSystem == null) {
+            pluginSystem = CoreRegistry.get(PluginSystem.class);
+        }
+    }
 
     @Override
     public BehaviorState modify(Actor actor, BehaviorState result) {

--- a/src/main/java/org/terasology/module/behaviors/actions/ValidatePath.java
+++ b/src/main/java/org/terasology/module/behaviors/actions/ValidatePath.java
@@ -38,7 +38,7 @@ public class ValidatePath extends BaseAction {
 
     @Override
     public void construct(Actor actor) {
-        // TODO: Temporary fix for injection malfunction in actions, remove as soon as injection malfunction in actions is fixed.
+        // TODO: Temporary fix for injection malfunction, remove once https://github.com/MovingBlocks/Terasology/issues/5004 is fixed.
         if (pluginSystem == null) {
             pluginSystem = CoreRegistry.get(PluginSystem.class);
         }


### PR DESCRIPTION
Contributes to https://github.com/MovingBlocks/Terasology/issues/4981

### What this PR does

Use initialization in construct() consistently throughout behavior actions

```java
@Override
public void construct(Actor actor) {
    if (world == null) {
        world = CoreRegistry.get(WorldProvider.class);
    }
}
```

- this will work if @in has no effect, i.e., the field is initialized to null
- this will work if @in is fixed and initializes the field correctly, making the code in construct a no-op
- we preserve the information that we want to use @in in actions

### Additional chores

- format prefabs (JSON)
- minor code simplification recommended by intellij in `CheckAttackStopAction` action