### PR TITLE
fix: Prevent movement to origin after spawning

### DIFF
--- a/src/main/java/org/terasology/module/behaviors/actions/FindPathToNode.java
+++ b/src/main/java/org/terasology/module/behaviors/actions/FindPathToNode.java
@@ -59,7 +59,15 @@ public class FindPathToNode extends BaseAction {
 
         MinionMoveComponent minionMoveComponent = actor.getComponent(MinionMoveComponent.class);
         Vector3ic start = Blocks.toBlockPos(actor.getComponent(LocationComponent.class).getWorldPosition(new Vector3f()));
-        Vector3ic goal = actor.getComponent(MinionMoveComponent.class).getPathGoal();
+        Vector3ic goal = minionMoveComponent.getPathGoal();
+
+        if (goal == null) {
+            // Special case to prevent pathfinding computation to (0,0,0) when the entity was just spawned.
+            // Returning early causes this action to terminate with BehaviorState.FAILURE on first execution
+            // of '#modify(Actor, BehaviorState)' as no pathfinding is running and the 'path' should still
+            // be empty.
+            return;
+        }
 
         JPSConfig config = new JPSConfig(start, goal);
         config.useLineOfSight = false;

--- a/src/main/java/org/terasology/module/behaviors/components/MinionMoveComponent.java
+++ b/src/main/java/org/terasology/module/behaviors/components/MinionMoveComponent.java
@@ -105,7 +105,7 @@ public final class MinionMoveComponent implements Component<MinionMoveComponent>
      * @param pos the final movement goal position
      */
     public void setPathGoal(Vector3i pos) {
-        goalPosition.set(pos);
+        setGoalPosition(pos);
         pathGoalEntity = null;
         resetPath();
     }


### PR DESCRIPTION
The MinionMoveComponent#goalPosition was initialized with the default vector (0,0,0), causing the _stray_ behavior to target this position as the first movement target.

As this origin location is usually not reachable when an entity is spawned, we wasted a couple of seconds for computing a path until we finally aborted as "not reachable".

With these changes, we can now distinguish between "no goal position" (null) and "explicit goal position" (any vector). We only attempt to find a path for non-null targets.
