### PR TITLE
Reformatting annotations of ``Behaviors``

### DIFF
--- a/src/test/java/org/terasology/module/behaviors/BehaviorTests.java
+++ b/src/test/java/org/terasology/module/behaviors/BehaviorTests.java
@@ -5,30 +5,25 @@ package org.terasology.module.behaviors;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.terasology.engine.entitySystem.entity.EntityManager;
 import org.terasology.engine.entitySystem.entity.EntityRef;
 import org.terasology.engine.entitySystem.prefab.Prefab;
-import org.terasology.engine.integrationenvironment.jupiter.Dependencies;
-import org.terasology.engine.integrationenvironment.jupiter.MTEExtension;
 import org.terasology.engine.logic.behavior.BehaviorComponent;
 import org.terasology.engine.logic.behavior.asset.BehaviorTree;
 import org.terasology.engine.registry.In;
 import org.terasology.gestalt.assets.ResourceUrn;
 import org.terasology.gestalt.assets.management.AssetManager;
+import org.terasology.engine.integrationenvironment.jupiter.IntegrationEnvironment;
 
 import java.util.Optional;
 import java.util.stream.Stream;
 
 
-@ExtendWith(MTEExtension.class)
-@Dependencies("Behaviors")
-@Tag("MteTest")
+@IntegrationEnvironment(dependencies = {"Behaviors"})
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class BehaviorTests {
 

--- a/src/test/java/org/terasology/module/behaviors/BehaviorTests.java
+++ b/src/test/java/org/terasology/module/behaviors/BehaviorTests.java
@@ -23,7 +23,7 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 
-@IntegrationEnvironment(dependencies = {"Behaviors"})
+@IntegrationEnvironment(dependencies = "Behaviors")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class BehaviorTests {
 

--- a/src/test/java/org/terasology/module/behaviors/MovementTests.java
+++ b/src/test/java/org/terasology/module/behaviors/MovementTests.java
@@ -11,8 +11,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -22,8 +20,6 @@ import org.terasology.engine.entitySystem.entity.EntityBuilder;
 import org.terasology.engine.entitySystem.entity.EntityManager;
 import org.terasology.engine.entitySystem.entity.EntityRef;
 import org.terasology.engine.integrationenvironment.ModuleTestingHelper;
-import org.terasology.engine.integrationenvironment.jupiter.Dependencies;
-import org.terasology.engine.integrationenvironment.jupiter.MTEExtension;
 import org.terasology.engine.logic.characters.CharacterMovementComponent;
 import org.terasology.engine.logic.location.LocationComponent;
 import org.terasology.engine.physics.engine.PhysicsEngine;
@@ -35,14 +31,13 @@ import org.terasology.engine.world.block.BlockRegion;
 import org.terasology.engine.world.block.BlockRegionc;
 import org.terasology.engine.world.block.Blocks;
 import org.terasology.module.behaviors.components.MinionMoveComponent;
+import org.terasology.engine.integrationenvironment.jupiter.IntegrationEnvironment;
 
 import java.util.Arrays;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-@Dependencies("Behaviors")
-@Tag("MteTest")
-@ExtendWith(MTEExtension.class)
+@IntegrationEnvironment(dependencies = {"Behaviors"})
 public class MovementTests {
     private static final Logger logger = LoggerFactory.getLogger(MovementTests.class);
 

--- a/src/test/java/org/terasology/module/behaviors/MovementTests.java
+++ b/src/test/java/org/terasology/module/behaviors/MovementTests.java
@@ -37,7 +37,7 @@ import java.util.Arrays;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-@IntegrationEnvironment(dependencies = {"Behaviors"})
+@IntegrationEnvironment(dependencies = "Behaviors")
 public class MovementTests {
     private static final Logger logger = LoggerFactory.getLogger(MovementTests.class);
 


### PR DESCRIPTION
Related issue: [#5087](https://github.com/MovingBlocks/Terasology/issues/5087)

The goal of this PR is to replace old annotations in ``BehavoirTests`` and ``MovementTests``