### PR TITLE
fix: use naiveMoveTo instead of moveTo Action

### DIFF
--- a/assets/behaviors/common/attackFollowedEntity.behavior
+++ b/assets/behaviors/common/attackFollowedEntity.behavior
@@ -23,7 +23,7 @@
                     }
                   }
                 },
-               move_to
+                {lookup: { tree: "Behaviors:naiveMoveTo" }}
               ]
             }
           ]


### PR DESCRIPTION
moveTo sets GoalEntity but doesnt update GoalPosition and path naiveMoveTo does

probably originates from pathfinding migration