### PR TITLE
fix(movement): stop NPCs teleporting to (0,0,0) while game is paused

### DIFF
--- a/src/main/java/org/terasology/module/behaviors/plugin/MovementPlugin.java
+++ b/src/main/java/org/terasology/module/behaviors/plugin/MovementPlugin.java
@@ -59,8 +59,19 @@ public abstract class MovementPlugin {
         LocationComponent location = entity.getComponent(LocationComponent.class);
         CharacterMovementComponent movement = entity.getComponent(CharacterMovementComponent.class);
 
+        float gameDelta = getTime().getGameDelta();
+        if (gameDelta <= 0) {
+            // The engine keeps ticking systems once per frame with a zero delta while the game is
+            // paused (e.g. the in-game menu is open in single player) rather than skipping them
+            // outright - see TimeBase#tick. Dividing by zero here turned a paused character's
+            // position into Infinity/NaN, teleporting it to (0, 0, 0) once that value round-tripped
+            // through later movement/physics code (MovingBlocks/Terasology#4995). No game time has
+            // passed, so there's nothing to move towards yet.
+            return new Vector3f();
+        }
+
         Vector3f delta = dest.sub(location.getWorldPosition(new Vector3f()), new Vector3f());
-        delta.div(movement.speedMultiplier).div(getTime().getGameDelta());
+        delta.div(movement.speedMultiplier).div(gameDelta);
         return delta;
     }
 }


### PR DESCRIPTION
Fixes MovingBlocks/Terasology#4995 - opening the in-game menu (pausing single player) sometimes corrupts a moving NPC's position to NaN, and it later gets shunted to (0, 0, 0) - well below the surface - once that propagates through engine physics/movement code.

## Root cause

`MovementPlugin.getDelta()` computes the velocity needed to cover the remaining distance to the destination in one game tick:

```java
Vector3f delta = dest.sub(location.getWorldPosition(new Vector3f()), new Vector3f());
delta.div(movement.speedMultiplier).div(getTime().getGameDelta());
```

The engine intentionally keeps ticking ECS systems once per frame while the game is paused, rather than skipping them outright - `TimeBase#tick` sets `gameDelta` to exactly `0` in that case instead of not returning an update cycle at all (Cervator's comment on the issue: "pausing is not actually total"). Dividing by that zero here produced `Infinity` (or `NaN` outright when the entity was already at its destination) in the direction the NPC was told to walk. That `CharacterMoveInputEvent` goes on to be consumed by the engine's `KinematicCharacterMover` and `BulletPhysics`, which is exactly where the "Can't update Trigger entity with a non-finite position/rotation" warning from the issue's logs comes from, and eventually the non-finite position/rotation reads back as `(0, 0, 0)` once it round-trips through further vector math.

## Fix

Return a zero delta - no movement - when the game clock isn't advancing, instead of dividing by it. This matches what the rest of the paused-tick machinery already does implicitly: `KinematicCharacterMover` multiplies displacement by the same zero delta downstream, so a character that was already moving correctly stays put while paused; this just stops the one place that divided by it from corrupting state in the process.

## Verification

`modules:Behaviors:compileJava` clean.

`modules:Behaviors:test --tests MovementTests` has some pre-existing flaky/failing cases unrelated to this change. I confirmed this by running `testCombinedMovement` against the fix and against the unmodified baseline back to back: both fail the same "up and down again" and "jump over" cases identically, and a third case ("down and up again") flips pass/fail across repeated runs on the *same unchanged* baseline code, confirming it's timing-flaky rather than something this PR introduces.

No existing test exercises the paused (`gameDelta == 0`) path directly - that needs driving `Time#setPaused` through a live tick loop, not something the current `MovementTests` harness does.
