### PR TITLE
fix(plugin): stop NPC movement going NaN while the game is paused

### DIFF
--- a/src/main/java/org/terasology/module/behaviors/plugin/MovementPlugin.java
+++ b/src/main/java/org/terasology/module/behaviors/plugin/MovementPlugin.java
@@ -59,12 +59,7 @@ public abstract class MovementPlugin {
         LocationComponent location = entity.getComponent(LocationComponent.class);
         CharacterMovementComponent movement = entity.getComponent(CharacterMovementComponent.class);
 
-        // getGameDelta() is exactly 0 while the game is paused (TimeBase#tick), but nothing gates
-        // behavior tree ticking on pause - so this runs every frame the pause menu is open too.
-        // Dividing by it then produced +/-Infinity, which propagated into the entity's actual
-        // position over subsequent frames and went NaN, at which point unrelated fallback logic
-        // (e.g. SetTargetToNearbyBlockNode) reset it to (0, 0, 0) - see #4995. No time having passed
-        // means no distance should be covered this call; a zero delta says exactly that.
+        // getGameDelta() is exactly 0 while the game is paused and dividing by 0 would produce +/-Infinity, where no movement has occurred.
         float gameDelta = getTime().getGameDelta();
         if (gameDelta <= 0 || movement.speedMultiplier <= 0) {
             return new Vector3f();

--- a/src/main/java/org/terasology/module/behaviors/plugin/MovementPlugin.java
+++ b/src/main/java/org/terasology/module/behaviors/plugin/MovementPlugin.java
@@ -59,8 +59,19 @@ public abstract class MovementPlugin {
         LocationComponent location = entity.getComponent(LocationComponent.class);
         CharacterMovementComponent movement = entity.getComponent(CharacterMovementComponent.class);
 
+        // getGameDelta() is exactly 0 while the game is paused (TimeBase#tick), but nothing gates
+        // behavior tree ticking on pause - so this runs every frame the pause menu is open too.
+        // Dividing by it then produced +/-Infinity, which propagated into the entity's actual
+        // position over subsequent frames and went NaN, at which point unrelated fallback logic
+        // (e.g. SetTargetToNearbyBlockNode) reset it to (0, 0, 0) - see #4995. No time having passed
+        // means no distance should be covered this call; a zero delta says exactly that.
+        float gameDelta = getTime().getGameDelta();
+        if (gameDelta <= 0 || movement.speedMultiplier <= 0) {
+            return new Vector3f();
+        }
+
         Vector3f delta = dest.sub(location.getWorldPosition(new Vector3f()), new Vector3f());
-        delta.div(movement.speedMultiplier).div(getTime().getGameDelta());
+        delta.div(movement.speedMultiplier).div(gameDelta);
         return delta;
     }
 }

--- a/src/test/java/org/terasology/module/behaviors/plugin/MovementPluginTest.java
+++ b/src/test/java/org/terasology/module/behaviors/plugin/MovementPluginTest.java
@@ -1,0 +1,77 @@
+// Copyright 2026 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+package org.terasology.module.behaviors.plugin;
+
+import org.joml.Vector3f;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.terasology.engine.core.Time;
+import org.terasology.engine.entitySystem.entity.EntityRef;
+import org.terasology.engine.logic.characters.CharacterMovementComponent;
+import org.terasology.engine.logic.location.LocationComponent;
+import org.terasology.engine.world.WorldProvider;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression test for #4995: an NPC's real position went NaN, and was later "fixed" to (0, 0, 0), while
+ * the in-game pause menu was open. {@code TimeBase#tick} sets {@code gameDelta} to exactly 0 while
+ * paused, but nothing gates behavior tree ticking on pause - so {@link MovementPlugin#getDelta} kept
+ * running every frame and divided by it unconditionally, producing +/-Infinity that eventually
+ * corrupted the entity's actual {@link LocationComponent}.
+ */
+public class MovementPluginTest {
+    private Time time;
+    private MovementPlugin plugin;
+    private EntityRef entity;
+    private LocationComponent location;
+    private CharacterMovementComponent movement;
+
+    @BeforeEach
+    public void setup() {
+        time = Mockito.mock(Time.class);
+        WorldProvider world = Mockito.mock(WorldProvider.class);
+        // WalkingMovementPlugin doesn't override getDelta - any concrete plugin exercises the same
+        // shared implementation in MovementPlugin.
+        plugin = new WalkingMovementPlugin(world, time);
+
+        location = new LocationComponent();
+        location.setWorldPosition(new Vector3f(0, 0, 0));
+        movement = new CharacterMovementComponent();
+
+        entity = Mockito.mock(EntityRef.class);
+        Mockito.when(entity.getComponent(LocationComponent.class)).thenReturn(location);
+        Mockito.when(entity.getComponent(CharacterMovementComponent.class)).thenReturn(movement);
+    }
+
+    @Test
+    public void getDeltaIsZeroWhenGameIsPaused() {
+        Mockito.when(time.getGameDelta()).thenReturn(0f);
+
+        Vector3f delta = plugin.getDelta(entity, new Vector3f(10, 0, 0));
+
+        assertThat(delta).isEqualTo(new Vector3f());
+    }
+
+    @Test
+    public void getDeltaIsZeroWhenSpeedMultiplierIsZero() {
+        Mockito.when(time.getGameDelta()).thenReturn(0.05f);
+        movement.speedMultiplier = 0;
+
+        Vector3f delta = plugin.getDelta(entity, new Vector3f(10, 0, 0));
+
+        assertThat(delta).isEqualTo(new Vector3f());
+    }
+
+    @Test
+    public void getDeltaIsFiniteUnderNormalConditions() {
+        Mockito.when(time.getGameDelta()).thenReturn(0.05f);
+
+        Vector3f delta = plugin.getDelta(entity, new Vector3f(10, 0, 0));
+
+        assertTrue(delta.isFinite());
+        assertThat(delta.x()).isGreaterThan(0f);
+    }
+}


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @soloturn via [GDD](https://github.com/soloturn/yggdrasil).

## Summary

Fixes MovingBlocks/Terasology#4995 - NPCs sometimes teleporting to (0, 0, 0) on opening the in-game menu.

`MovementPlugin.getDelta` divided by `Time#getGameDelta` unconditionally. `TimeBase#tick` sets `gameDelta` to exactly 0 while the game is paused (e.g. the in-game menu is open), but nothing gates behavior tree ticking on pause - so `getDelta` kept running every frame the menu stayed open and divided by zero, producing +/-Infinity. That propagated into the entity's actual `LocationComponent` over subsequent frames and went NaN, at which point unrelated fallback logic (e.g. `SetTargetToNearbyBlockNode`, whose default start position is `(0, 0, 0)`) reset the entity there - matching this issue's exact log sequence: repeated `"Can't update Trigger entity with a non-finite position/rotation"` warnings, then a NaN position, then landing at the world origin.

## Changes

`getDelta` now returns a zero vector - no distance covered, correctly - when either divisor (game delta or the entity's speed multiplier) is non-positive, instead of dividing by it. All five movement plugins (`Walking`/`Flying`/`Swimming`/`Falling`/`Leaping`) share this one method, so one fix covers all of them.

## Test plan

- [x] New `MovementPluginTest` (3/3 pass): paused (zero game delta) and zero-speed-multiplier both produce a zero delta instead of a non-finite one; a normal call still produces a finite, correctly-directed delta.
- [x] Existing `MovementTests` (36/36 pass, `testWalkingMovement` and related parameterized cases) - unaffected, since the fix only short-circuits the two degenerate cases and leaves the normal-path computation untouched.
